### PR TITLE
Structural refractor and new CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ Below we document the literature sources used for parameter selection.
 | sinus               | –       | –       | –        | –      | -     |
 | inter_vert_discs    | 1201    | 42      | 26       | 50     | -9.055|
 
+## Permittivity and conductivity
+
+| Tissue/Label | Relative Permittivity @3T(εr) | Conductivity @3T (S/m) | Relative Permittivity @7T(εr) | Conductivity @7T (S/m) |
+|--------------|----------------------------|-------------------|---------|------------------------|
+| Fat | 48.17 | 0.52 | 44.25 | 0.562 |
+| Brain | 79.80 | 0.829 | 59.8 | 0.972 |
+| Muscle | 63.5 | 0.719 | 58.2 | 0.770 |
+| Bone (Cortical) | 14.7 | 0.0673 | 13.4 | 0.0825 |
+| Vertebral Bone | 14.7 | 0.0673 | 13.4 | 0.0825 |
+| Lungs (Inflated) | 29.5 | 0.316 | 24.8 | 0.356 |
+| Trachea | 50.6 | 0.559 | 45.3 | 0.610 |
+| Air | 1.0 | 0 | 1.0 | 0 |
+| Spinal Cord | 44.1 | 0.354 | 36.9 | 0.418 |
+| Spinal Cord WM | 44.1 | 0.354 | 36.9 | 0.418 |
+| Spinal Cord GM | 44.1 | 0.354 | 36.9 | 0.418 |
+| CSF | 84.1 | 2.14 | 72.8 | 2.22 |
+| Organ (Kidney as reference) | 89.7 | 0.852 | 70.6 | 1.02 |
+| Sinus | 5.435 | 0.0426 | 4.48 | 0.051 |
+| Ear Canal | 5.435 | 0.0426 | 4.48 | 0.051 |
+| Intervertebral Disc (cartilage) | 52.9 | 0.488 | 46.8 | 0.552 |
+| Cartilage | 89.7 | 0.852 | 70.6 | 1.02 |
+| Skull | 14.7 | 0.0673 | 13.4 | 0.0825 |
+| Eyes | 84.1 | 2.14 | 72.8 | 2.22 |
+
 
  
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Each voxel in a segmentation file must contain one of the following integer IDs.
 | 102          | organ            |
 | 107          | tr_cartilage     |
 | 113          | tr_lumen         |
+| 117          | sinus            |
+| 119          | ear_canal        |
 | 196          | sc_wm            |
 | 264          | fat              |
 | 289          | sc_csf           |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ pip install .
 All inputs and outputs are NIfTI volumes (`.nii` or `.nii.gz`).  
 Unless otherwise specified, outputs are written as compressed NIfTI files (`.nii.gz`) inside the `output/` directory.
 
-## `seg_sorter`
+## `seg_converter`
 
 Remaps a segmentation volume to the canonical label convention.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,101 @@
 # <div align="center">**Segmentation to MR Properties Converter**</div>
 
-This repository will contain the code necessary for creating different (and selected) volumes whose values represent different MR useful properties: T2, T2 star, Proton Density and Susceptibility.
+This repository contains the code required to generate quantitative magnetic resonance (MR) property volumes, including:
+
+- **T1 relaxation maps (3T)**
+- **T2 relaxation maps (3T)**
+- **T2\* relaxation maps (3T)**
+- **Relative permittivity maps (3T and 7T)**
+- **Electrical conductivity maps (3T and 7T)**
+- **Proton density maps**
+- **Absolute magnetic susceptibility maps**
 
 # Phantom Creation
 
-This tool requires that the segmentation nifti file provided has already been added to the repositories dictionary of vlaues. We initially used the output from Total Segmentator [1] to group into broader tissue types. </br>
-We implement an object-oriented python code that relies on the labels look up table. We implement 2 classes: Volume and Label. They have a parent-daughter relationship. The volume is the nifti file from which we can access information from the header such as dimensions or voxel size and assign them as attributes to the Volume. Then we instance a label class for every unique label from the input, where MR properties are assigned to them as attributes such as: Proton Density, Net Magnetization, T1, T2, T2 star and susceptibility; as well as an identifying ID number and a name. 
+All input segmentation files must follow the canonical label convention defined below.  
+Each voxel in a segmentation file must contain one of the following integer IDs.
 
-A parcellation color map for the TotalCT version "mod 2" for ITK-snap is provided [here](parcellation_itk.txt). This file encodes labels 1 to 48 with a name according to the label it will have; labels 49 to 67, 72, 72, 77 to 86 are named "extra" as they do not have a fixed name in the label class. An example of the final output color scheme is shown below.
+| Canonical ID | Tissue Name      |
+|--------------|------------------|
+| 0            | air              |
+| 1            | heart            |
+| 2            | liver            |
+| 4            | kidney           |
+| 5            | brain            |
+| 6            | spleen           |
+| 7            | cartilage        |
+| 9            | muscle           |
+| 10           | bone             |
+| 11           | v_bone(vertebrae)|
+| 12           | lungs            |
+| 13           | trachea          |
+| 14           | spinal_cord      |
+| 18           | esophagus        |
+| 19           | gland            |
+| 100          | extra            |
+| 101          | water            |
+| 102          | organ            |
+| 107          | tr_cartilage     |
+| 113          | tr_lumen         |
+| 196          | sc_wm            |
+| 264          | fat              |
+| 289          | sc_csf           |
+| 324          | sc_gm            |
 
-![image](https://github.com/sriosq/brainhack_project/assets/154398382/36e16ab6-0683-4455-bec4-4337bb7bb975)
+A parcellation color map for the canonical ID's can be used with ITK[1] available [here](parcellation_itk.txt)
+
+
+---
+
+## Tool 1: `seg_converter`
+
+Different segmentation tools use different labeling conventions.  
+To ensure consistency across datasets, this repository provides the `seg_converter` command line tool (CLI).
+
+### Supported Segmentation Sources
+
+Currently implemented:
+
+- Total Segmentator CT [2]
+- Total Segmentator MRI
+
+### How It Works
+
+1. The user provides:
+   - The segmentation volume
+   - The segmentation tool used to generate it
+
+2. The tool:
+   - Verifies that all voxel label IDs match the expected IDs for the selected segmentation tool.
+   - Remaps the segmentation labels to the canonical label IDs.
+
+3. If any voxel contains an unidentified label ID:
+   - A binary mask is generated containing only those invalid voxels.
+   - This mask allows the user to manually inspect and correct unexpected labels before proceeding.
+
+This validation step ensures that all downstream MR property generation is physically consistent and reproducible.
+
+---
+
+## Tool 2: `tissue_to_MR`
+
+Once a segmentation has been successfully remapped to the canonical label convention, it can be converted into quantitative MR property volumes using `tissue_to_MR` CLI.
+
+### Purpose
+
+`tissue_to_MR` transforms a canonical segmentation into a voxel-wise MR property map.
+
+### Supported Properties
+
+The user specifies which physical property to generate, including:
+
+- T1 (3T)
+- T2 (3T)
+- T2*
+- Relative permittivity (3T or 7T)
+- Electrical conductivity (3T or 7T)
+- Proton density
+- Absolute magnetic susceptibility
 
 # Installation
 
@@ -33,37 +119,59 @@ pip install .
 
 # Usage
 
-Once in the package is installed, you can process your images directly from the terminal. A description follows. </br>
+All inputs and outputs are NIfTI volumes (`.nii` or `.nii.gz`).  
+Unless otherwise specified, outputs are written as compressed NIfTI files (`.nii.gz`) inside the `output/` directory.
 
-**Arguments** 
-- -i, input filename (expected to be compressed nifti, must end in .nii.gz)
-- -s, segmentation_tool : ['TotalSeg_CT','TotalSeg_MRI','ProCord_MRI','compare_fm']
-- -v, version : ['v1','v2','mod0','mod1','mod2','dyn']
-- -t, type : ["t2s", "sus", "pd", "t1", "t2"]
-- -g, gauss : ["0", "1"]
-- -x, Susceptibility value (only used if tool is compare_fm tool and version is dynamic, changes the value susceptibility of Trachea and Lung labels)
-- -r, Use as reference value to demodulate the susceptibility property to create different referenced Chi-maps
-- -o, output filename (expected to be compressed nifti, must end in .nii.gz)
+## `seg_sorter`
+
+Remaps a segmentation volume to the canonical label convention.
+
+### Arguments
+
+| Flag | Description | Options |
+|------|------------|----------|
+| `-i` | Input segmentation file | `.nii` or `.nii.gz` |
+| `-s` | Segmentation tool used | `TotalSeg_CT`, `TotalSeg_MRI` |
+| `-v` | Version of the segmentation labeling scheme | `v1`, `v2`, `mod0`, `mod1`, `mod2`|
+| `-o` | Output remapped file | `.nii.gz` |
+
 
 Example:
-```
-tissue_to_mr -i data/correct_pixels.nii.gz -i iMag_dub07.nii.gz -s TotalSeg_CT -v mod2 -t sus -g 1 -o dub07_gauss_sus_phantom.nii.gz
-```
 
 ```
-tissue_to_MR -i iMag_dub07.nii.gz -s compare_fm -v dyn -t sus -x -4.36 -o custom_dub07_sus_phantom.nii.gz
+seg_converter -i data/input_file.nii.gz -s TotalSeg_CT -v v2 -o remapped_input_file.nii.gz
 ```
 
-**Output** The new volume will be saved as Nifti inside the *output* folder. </br>
 
-The tool performs a **pixel_check** function that will run before running the conversion. If the function finds a pixel with label intensity value outside the known labels in the dictionary provided by *-s*, segmentation label, the tool will ask to change the value of the pixel or delete this pixel (set value to 0). If the code changes any value, it will automatically save a new Nifti image in the output folder with name: **corrected_pixels.nii.gz**.
+## `tissue_to_MR`
 
-The tool has an option of creating the phantom with a Gaussian (normal) distribution based on: the total count of pixels per label and using the fixed value on the look-up table as the mean. Currently only supported for **t2s**, **pd** and **sus** volume creation.
+Converts a canonical segmentation volume into a quantitative MR property map by replacing each tissue label with its corresponding physical value.
 
-Depending on the tool used for segmentation the code will use different lookup tables for label id-name relationship. </br>
+### Arguments
 
-# Look-up table
-Here we document the respective look-up tables used for assigning MR property values to labels. This are acquired from literature publications, reference to the literature used for creating the look-up table are inside the code for the [label](functions/label.py) class.
+| Flag | Description | Options |
+|------|------------|---------|
+| `-i` | Input canonical segmentation file | `.nii.gz` |
+| `-t` | Property type to generate | `t2s`, `sus`, `pd`, `t1`, `t2`, `perm3T`, `cond3T`, `perm7T`, `cond7T` |
+| `-g` | Apply Gaussian distribution in spinal cord WM and GM | `0` (disabled), `1` (enabled) |
+| `-o` | Output filename | `.nii.gz` |
+
+### Output
+
+The generated MR property volume is saved in the `output/` directory.
+
+If `-g 1` is enabled, voxel values within **spinal cord white matter (`sc_wm`)** and **spinal cord gray matter (`sc_gm`)** are sampled from a Gaussian (normal) distribution centered on the nominal property values. All other tissues are assigned fixed (deterministic) values.
+
+
+
+# Look-Up Tables (LUT)
+
+MR property values assigned to each tissue are derived from peer-reviewed literature.
+
+Each physical property (T1, T2, T2*, susceptibility, permittivity, conductivity, etc.) has its own look-up table defined in the corresponding class within the codebase.
+
+Below we document the literature sources used for parameter selection.
+
 
 ## Relaxation Values & Susceptibility
 
@@ -84,8 +192,9 @@ Here we document the respective look-up tables used for assigning MR property va
 | muscle              | 1237.825| 36.1    | 24.1     | 45     | -9.03 |
 | bone                | 223     | 0.39    | 1.16     | 18     | -11.1 |
 | v_bone (Vertebrae)  | 618.5   | 80.685  | 40.3     | 40     | -9.7  |
-| lungs               | 1400    | 35.5    | 1.62     | 15     | -0.27* |
-| trachea             | 1100    | 40      | 12       | 5      | -4.36* |
+| lungs               | 1400    | 35.5    | 1.62     | 15     | -2.36 |
+| trachea cartilage   | 1201    | 43.225      | 26.04       | 70      | -9.05 |
+| trachea lumen       | 0.01    | 0.01      | 0.01       | 0.01      | 0.196 |
 | air                 | 0.01    | 0.01    | 0.01     | 0.01   | 0.35  |
 | extra (blood/muscle)| 800     | 50      | 35       | 50     | -9.04 |
 | spinal_cord         | 936.5   | 76.75   | 40.07    | 60     | -9.055|
@@ -93,7 +202,6 @@ Here we document the respective look-up tables used for assigning MR property va
 | CSF                 | 1953    | 275     | 137.5    | 100    | -9.05 |
 | white_matter        | 887.7   | 65.4    | 35       | 70     | –     |
 | gray_matter         | 1446.1  | 94.3    | 48       | 82     | –     |
-| SpinalCanal         | 993     | 78      | 39       | 90     | -9.055|
 | esophagus           | 1000    | 32      | 17       | 45     | -9.05 |
 | organ (liver-like)  | 800     | 40      | 20       | 65     | -9.05 |
 | gland (salivary)    | 1600    | 72      | 36       | 80     | -9.05 |
@@ -101,16 +209,8 @@ Here we document the respective look-up tables used for assigning MR property va
 | inter_vert_discs    | 1201    | 42      | 26       | 50     | -9.055|
 
 
-* Susceptibility for Air cavities: lungs & trachea are guesses from a WIP project.
-
-Citation to come with publication soon!. </br>
-
-# Adding Labels - Modified Nifti
-
-One of the current limitations of the output from Total Segmentator is the label definition for the Spinal Cord. This encouraged us to add new labels to the phantom. </br>
-In the following [repository](https://github.com/sriosq/Image-processing-strategies) you will find usefull strategies and code to create new labels as well as adding them to a segmented image.
-If you would like help adding labels or would like to create a new segmentation tool to easily convert please create a new issue or contact us!
+ 
 
 # References 
-
-[1] Wasserthal, J., Breit, H.-C., Meyer, M.T., Pradella, M., Hinck, D., Sauter, A.W., Heye, T., Boll, D., Cyriac, J., Yang, S., Bach, M., Segeroth, M., 2023. TotalSegmentator: Robust Segmentation of 104 Anatomic Structures in CT Images. Radiology: Artificial Intelligence. https://doi.org/10.1148/ryai.230024 </br>
+[1] Paul A. Yushkevich, Joseph Piven, Heather Cody Hazlett, Rachel Gimpel Smith, Sean Ho, James C. Gee, and Guido Gerig. User-guided 3D active contour segmentation of anatomical structures: Significantly improved efficiency and reliability. Neuroimage 2006 Jul 1;31(3):1116-28.
+[2] Wasserthal, J., Breit, H.-C., Meyer, M.T., Pradella, M., Hinck, D., Sauter, A.W., Heye, T., Boll, D., Cyriac, J., Yang, S., Bach, M., Segeroth, M., 2023. TotalSegmentator: Robust Segmentation of 104 Anatomic Structures in CT Images. Radiology: Artificial Intelligence. https://doi.org/10.1148/ryai.230024 </br>

--- a/parcellation_itk.txt
+++ b/parcellation_itk.txt
@@ -130,6 +130,8 @@
   115   255  255  255        1  1  1    "Bone"
   116   255  255  255        1  1  1    "Bone"
   117   132  204  199        1  1  1    "Costal Cartilage"
+  170   229  229   53        1  1  1    "Trachea Cartilage"
+  171    53  226  229        1  1  1    "Trachea Lumen"
   196   216   41  172        1  1  1    "Spinal Cord WM"
   256     8   97   78        1  1  1    "Spinal Cord"
   264    97   78   56        1  1  1    "Fat & Muscle"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.scripts]
 tissue_to_MR = "tissue2mrprop.cli.tissue_to_mr:converter"
+seg_converter = "tissue2mrprop.cli.tissue_to_mr:seg_sorter"
 mr_prop_viewer = "tissue2mrprop.cli.display:display"
 
 [tool.setuptools.packages.find]

--- a/tissue2mrprop/cli/tissue_to_mr.py
+++ b/tissue2mrprop/cli/tissue_to_mr.py
@@ -174,6 +174,120 @@ def converter(input_file, segtool, version, type, gauss, chi, ref, output_file):
     with open(json_out_path, 'w', encoding='utf-8') as f:
         json.dump(converter_sidecar, f, ensure_ascii=False, indent=4)
 
+    def seg_sorter(input_file, segtool, version, output_file, chi=None):
+        command = " ".join(sys.argv)
+
+        # We need to check if the input is a  nifti file
+        if is_nifti(input_file):
+            start = time.time()
+            print("start")
+            # logging.info(f"Creating a new volume with {type} values")
+            file = nib.load(input_file)
+            print("file loaded")
+            new_vol = volume(file)
+            print("# Step 1. Group segmentation labels #")
+            # Using the type:
+
+            # This for the FM comparison project:
+            # Needs to be before grouping labels, if not it will put none
+            if segtool == "compare_fm" and version == "dyn":
+                if chi != None:
+                    new_vol.new_chi = chi  # This needs to be improved ... (S.R. comment)
+                    print("Using new susceptibility value for air: ", chi)
+                else:
+                    print("When using new dynamic version you must provide a chi value")
+                    new_vol.new_chi = -2.438
+                    print("Using default: ", new_vol.new_chi)  # Value found while Optimization Abstract work
+                    # Is a value used in single value optimization of measured FM vs simulated FM
+            if ref != 0:
+                if type == 'sus':
+                    new_vol.group_seg_labels(segtool, version, type,
+                                             ref=ref)  # Automatically adding the names to known labels
+                    print(f"Using {ref} as a reference value")
+                else:
+                    print("Type must be susceptibility to use the reference flag")
+                    exit()
+
+            new_vol.group_seg_labels(segtool, version, type, ref=ref)
+            # Printing one label can help see the structure as well as verifying values selected
+            # Specially when working with field map comparison project where chi can be changed
+
+            print("# Step 2. Checking pixel integrity #")
+            ans = new_vol.check_pixels(input_file)
+
+            if ans == 0:
+                print("# Step 3. Converting ... #")
+
+                if gauss == "1":
+
+                    new_vol.gauss_flag = 1
+                    print("Gaussian option enabled ...")
+                    new_vol.calc_regions()
+                    # print("Calc region done")
+                    new_vol.create_gauss_sc_dist(type)
+                    print("Creating a Gaussian distribution phantom from ", type, " values")
+                    if output_file == None:
+                        new_vol.save_gauss_dist(type)
+                        print("Gaussian phantom created")
+                    else:
+                        new_vol.save_gauss_dist(type, output_file)
+                        print("Gaussian phantom created - custom out_fn")
+
+                else:
+
+                    if output_file == None:
+                        print("Piece-wise mode: on")
+                        new_vol.create_type_vol(type)  # This creates and saves a Nifti file
+
+                    else:
+                        print("Piece-wise ON - custom out_fn")
+                        new_vol.create_type_vol(type, output_file)
+
+                print(f"Input segmented by: {segtool}, version: {version}")
+                end = time.time()
+                elapsed = end - start
+                print("Time elapsed: ", elapsed)
+
+            else:
+
+                print("Pixel integrity error")
+
+        else:
+            print("Input must be a Nifti file (.nii or .nii.gz extensions)")
+
+        # After everything is finished, we can create the json side car
+        try:
+            repo = git.Repo(search_parent_directories=True)
+        except git.exc.InvalidGitRepositoryError:
+            # This in case that converter tool is not ran under the folder
+            print("No Git repository found in parent directories.")
+            repo = None
+        print("# Step 3. Creating json sidecar for the convertion #")
+
+        converter_sidecar = {}
+        # This depends on the OS system
+        author_name = os.getenv('USER') or os.getenv('USERNAME') or os.getenv('LOGNAME')
+        converter_sidecar['author'] = author_name if author_name else "Unknown User"
+        converter_sidecar['date'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        converter_sidecar['script'] = str(Path(os.path.abspath(__file__)).resolve())
+        converter_sidecar['command'] = command
+        if repo:
+            converter_sidecar['script source'] = repo.remotes.origin.url
+            converter_sidecar['script commit hash'] = repo.head.object.hexsha
+        else:
+            converter_sidecar['script source'] = "tissue_to_MR"
+            converter_sidecar['script commit hash'] = "check with git status"
+
+        json_out_name = output_file.replace(".nii.gz", ".json")
+        json_out_path = os.path.join("output", json_out_name)
+        print(json_out_path)
+        if os.path.exists(json_out_path):
+            print("Json sidecar found, overwritting ...")
+            os.remove(json_out_path)
+
+        with open(json_out_path, 'w', encoding='utf-8') as f:
+            json.dump(converter_sidecar, f, ensure_ascii=False, indent=4)
+
 #my_commands.add_command(converter)
 #if __name__ == "__main__":
 #    my_commands()

--- a/tissue2mrprop/cli/tissue_to_mr.py
+++ b/tissue2mrprop/cli/tissue_to_mr.py
@@ -49,14 +49,15 @@ PROPERTIES = {
 @click.command()
 @click.option('-i','--input','input_file', type=click.Path(exists=True), required=True,
               help="Input segmentations distribution, supported extensions: .nii, .nii.gz")
-@click.option('-s',"--segtool",required=True,type=click.Choice(['TotalSeg_CT','TotalSeg_MRI','ProCord_MRI', 'charles','compare_fm']), help="State what segmentator was used")
-@click.option('-v',"--version",required=True,type=click.Choice(['v1','v2','mod0','mod1','mod2','dyn','mod_PAM50',"ds005616"]), help="Select the version of your segmentation file")
+@click.option('-s',"--segtool",required=True,type=click.Choice(['TotalSeg_CT','TotalSeg_MRI','ProCord_MRI', 'charles','compare_fm','bracesTS']), help="State what segmentator was used")
+@click.option('-v',"--version",required=True,type=click.Choice(['v1','v2','mod0','mod1','mod2','mod3','dyn','mod_PAM50',"ds005616"]), help="Select the version of your segmentation file")
 @click.option('-t',"--type",required=True, type=click.Choice(PROPERTIES.keys()), help="Please choose MR property to convert to")
 @click.option("-g", "--gauss",required=False, type= click.Choice(["0","1"]), default = "0", help = "Set to 1 to use Gaussian distribution")
 @click.option("-x","--chi", required = False, type = float, default = None, help = "Used to define new chi value for FM comparison approach")
 @click.option("-r", "--ref",required=False,type=float,default=0,help="Use as a reference flag to demodulate the values by a constant. Only use with Susceptibility property")
 @click.option('-o', '--output', 'output_file', type=click.Path(), default= "sus_dist.nii.gz", required= False,
               help = "By default it saves the chimap to the output folder")
+
 def converter(input_file, segtool, version, type, gauss, chi, ref, output_file):
 
     # Pulling information of the command for output json file

--- a/tissue2mrprop/cli/tissue_to_mr.py
+++ b/tissue2mrprop/cli/tissue_to_mr.py
@@ -3,6 +3,8 @@ import time
 import click
 import logging
 import nibabel as nib
+from nibabel import Nifti1Image
+
 # With the next line we add to path the project folder to navigate into functions folder
 #sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -13,7 +15,7 @@ from tissue2mrprop.functions.utils.utils import is_nifti
 
 import time
 
-# For the json sidecar
+# For the JSON sidecar
 from pathlib import Path
 import argparse
 import os
@@ -49,97 +51,56 @@ PROPERTIES = {
 @click.command()
 @click.option('-i','--input','input_file', type=click.Path(exists=True), required=True,
               help="Input segmentations distribution, supported extensions: .nii, .nii.gz")
-@click.option('-s',"--segtool",required=True,type=click.Choice(['TotalSeg_CT','TotalSeg_MRI','ProCord_MRI', 'charles','compare_fm','bracesTS']), help="State what segmentator was used")
-@click.option('-v',"--version",required=True,type=click.Choice(['v1','v2','mod0','mod1','mod2','mod3','dyn','mod_PAM50',"ds005616"]), help="Select the version of your segmentation file")
 @click.option('-t',"--type",required=True, type=click.Choice(PROPERTIES.keys()), help="Please choose MR property to convert to")
 @click.option("-g", "--gauss",required=False, type= click.Choice(["0","1"]), default = "0", help = "Set to 1 to use Gaussian distribution")
-@click.option("-x","--chi", required = False, type = float, default = None, help = "Used to define new chi value for FM comparison approach")
-@click.option("-r", "--ref",required=False,type=float,default=0,help="Use as a reference flag to demodulate the values by a constant. Only use with Susceptibility property")
 @click.option('-o', '--output', 'output_file', type=click.Path(), default= "sus_dist.nii.gz", required= False,
               help = "By default it saves the chimap to the output folder")
 
-def converter(input_file, segtool, version, type, gauss, chi, ref, output_file):
+def converter(input_file, type, gauss, output_file):
 
-    # Pulling information of the command for output json file
+    # Pulling information of the command for output JSON file
     command = " ".join(sys.argv)
+    if not is_nifti(input_file):
+        print("Input must be a Nifti file (.nii or .nii.gz extensions)")
+        return
 
-    # We need to check if the input is a  nifti file
-    if is_nifti(input_file):
-        start = time.time()
-        print("start")
-        #logging.info(f"Creating a new volume with {type} values")
-        print(f"Creating a new volume with {type} values")
-        file = nib.load(input_file)
-        print("file loaded")
-        new_vol = volume(file)
-        print("# Step 1. Group segmentation labels #")
-        # Using the type:
+    start = time.time()
+    print("start")
+    #logging.info(f"Creating a new volume with {type} values")
+    print(f"Creating a new volume with {type} values")
+    file = nib.load(input_file)
+    print("File loaded")
+    new_vol = volume(file)
 
-        # This for the FM comparison project:
-        # Needs to be before grouping labels, if not it will put none
-        if segtool == "compare_fm" and version == "dyn":
-            if chi != None:
-                new_vol.new_chi = chi # This needs to be improved ... (S.R. comment)
-                print("Using new susceptibility value for air: ",chi)
-            else:
-                print("When using new dynamic version you must provide a chi value")
-                new_vol.new_chi = -2.438
-                print("Using default: ", new_vol.new_chi) # Value found while Optimization Abstract work
-                # Is a value used in single value optimization of measured FM vs simulated FM
-        if ref != 0:
-            if type == 'sus':
-                new_vol.group_seg_labels(segtool, version,type, ref = ref)  # Automatically adding the names to known labels
-                print(f"Using {ref} as a reference value")
-            else:
-                print("Type must be susceptibility to use the reference flag")
-                exit()
+    print("# Step 1. Initializing ... #")
+    new_vol.init_segmentation_labels_from_canonical()
 
-        new_vol.group_seg_labels(segtool, version, type, ref=ref)
-        # Printing one label can help see the structure as well as verifying values selected
-        # Specially when working with field map comparison project where chi can be changed
-
-        print("# Step 2. Checking pixel integrity #")
-        ans = new_vol.check_pixels(input_file)
-
-        if ans == 0:
-            print("# Step 3. Converting ... #")
-
-            if gauss == "1":
-
-                new_vol.gauss_flag = 1
-                print("Gaussian option enabled ...")
-                new_vol.calc_regions()
-                # print("Calc region done")
-                new_vol.create_gauss_sc_dist(type)
-                print("Creating a Gaussian distribution phantom from ", type, " values")
-                if output_file == None:
-                    new_vol.save_gauss_dist(type)
-                    print("Gaussian phantom created")
-                else:
-                    new_vol.save_gauss_dist(type,output_file)
-                    print("Gaussian phantom created - custom out_fn")
-
-            else:
-
-                if output_file == None:
-                    print("Piece-wise mode: on")
-                    new_vol.create_type_vol(type)  # This creates and saves a Nifti file
-
-                else:
-                    print("Piece-wise ON - custom out_fn")
-                    new_vol.create_type_vol(type, output_file)
-
-            print(f"Input segmented by: {segtool}, version: {version}")
-            end = time.time()
-            elapsed = end-start
-            print("Time elapsed: ",elapsed)
-
+    if gauss == "1":
+        new_vol.gauss_flag = 1
+        print("Gaussian option enabled ...")
+        new_vol.calc_regions()
+        # print("Calc region done")
+        new_vol.create_gauss_sc_dist(type)
+        print("Creating a Gaussian distribution phantom from ", type, " values")
+        if output_file:
+            print("Gaussian phantom created - custom out_fn")
+            new_vol.save_gauss_dist(type,output_file)
         else:
-
-            print("Pixel integrity error")
+            print("Gaussian phantom created")
+            new_vol.save_gauss_dist(type)
 
     else:
-        print("Input must be a Nifti file (.nii or .nii.gz extensions)")
+        if output_file:
+            print("Piece-wise ON - custom out_fn")
+            new_vol.create_type_vol(type, output_file)  # This creates and saves a Nifti file
+        else:
+            print("Piece-wise ON")
+            new_vol.create_type_vol(type)
+
+    end = time.time()
+    elapsed = end-start
+    print(f"Time elapsed: {elapsed:.4f} seconds")
+
 
     # After everything is finished, we can create the json side car
     try:
@@ -174,119 +135,41 @@ def converter(input_file, segtool, version, type, gauss, chi, ref, output_file):
     with open(json_out_path, 'w', encoding='utf-8') as f:
         json.dump(converter_sidecar, f, ensure_ascii=False, indent=4)
 
-    def seg_sorter(input_file, segtool, version, output_file, chi=None):
-        command = " ".join(sys.argv)
+@click.command()
+@click.option('-i','--input','input_file', type=click.Path(exists=True), required=True,
+              help="Input segmentations distribution, supported extensions: .nii, .nii.gz")
+@click.option('-s',"--segtool",required=True,type=click.Choice(['TotalSeg_CT','TotalSeg_MRI','ProCord_MRI', 'charles','compare_fm','bracesTS']), help="State what segmentator was used")
+@click.option('-v',"--version",required=True,type=click.Choice(['v1','v2','mod0','mod1','mod2','mod3','dyn','mod_PAM50',"ds005616"]), help="Select the version of your segmentation file")
+@click.option('-o', '--output', 'output_file', type=click.Path(), default= "sus_dist.nii.gz", required= False,
+              help = "By default it saves the chimap to the output folder")
+def seg_sorter(input_file, segtool, version, output_file):
+    command = " ".join(sys.argv)
 
-        # We need to check if the input is a  nifti file
-        if is_nifti(input_file):
-            start = time.time()
-            print("start")
-            # logging.info(f"Creating a new volume with {type} values")
-            file = nib.load(input_file)
-            print("file loaded")
-            new_vol = volume(file)
-            print("# Step 1. Group segmentation labels #")
-            # Using the type:
+    # We need to check if the input is a  nifti file
+    if not is_nifti(input_file):
+        print("Input must be a Nifti file (.nii or .nii.gz extensions)")
+        return
+    start = time.time()
+    print("Begin")
+    file = nib.load(input_file)
+    print("File loaded")
+    vol = volume(file)
+    print("# Step 1. Group segmentation labels #")
 
-            # This for the FM comparison project:
-            # Needs to be before grouping labels, if not it will put none
-            if segtool == "compare_fm" and version == "dyn":
-                if chi != None:
-                    new_vol.new_chi = chi  # This needs to be improved ... (S.R. comment)
-                    print("Using new susceptibility value for air: ", chi)
-                else:
-                    print("When using new dynamic version you must provide a chi value")
-                    new_vol.new_chi = -2.438
-                    print("Using default: ", new_vol.new_chi)  # Value found while Optimization Abstract work
-                    # Is a value used in single value optimization of measured FM vs simulated FM
-            if ref != 0:
-                if type == 'sus':
-                    new_vol.group_seg_labels(segtool, version, type,
-                                             ref=ref)  # Automatically adding the names to known labels
-                    print(f"Using {ref} as a reference value")
-                else:
-                    print("Type must be susceptibility to use the reference flag")
-                    exit()
+    grouped_passed = vol.group_seg_labels(segtool, version, input_file)
+    # If we group the labels and no ID is missing (automatically checked inside)
+    # Now we can get the new seg file with
+    if grouped_passed:
+        new_seg_file = vol.create_new_grouped_labels()
+    # Now save the new seg_file
+        new_seg_img = Nifti1Image(new_seg_file,header=file.header,affine= file.affine)
+        nib.save(new_seg_img, output_file)
+        end = time.time()
+        elapsed = end - start
+        print(f"Time elapsed: {elapsed:.4f} seconds")
+    else:
+        print("Failed pixel checking please check input file and the created mask file")
 
-            new_vol.group_seg_labels(segtool, version, type, ref=ref)
-            # Printing one label can help see the structure as well as verifying values selected
-            # Specially when working with field map comparison project where chi can be changed
-
-            print("# Step 2. Checking pixel integrity #")
-            ans = new_vol.check_pixels(input_file)
-
-            if ans == 0:
-                print("# Step 3. Converting ... #")
-
-                if gauss == "1":
-
-                    new_vol.gauss_flag = 1
-                    print("Gaussian option enabled ...")
-                    new_vol.calc_regions()
-                    # print("Calc region done")
-                    new_vol.create_gauss_sc_dist(type)
-                    print("Creating a Gaussian distribution phantom from ", type, " values")
-                    if output_file == None:
-                        new_vol.save_gauss_dist(type)
-                        print("Gaussian phantom created")
-                    else:
-                        new_vol.save_gauss_dist(type, output_file)
-                        print("Gaussian phantom created - custom out_fn")
-
-                else:
-
-                    if output_file == None:
-                        print("Piece-wise mode: on")
-                        new_vol.create_type_vol(type)  # This creates and saves a Nifti file
-
-                    else:
-                        print("Piece-wise ON - custom out_fn")
-                        new_vol.create_type_vol(type, output_file)
-
-                print(f"Input segmented by: {segtool}, version: {version}")
-                end = time.time()
-                elapsed = end - start
-                print("Time elapsed: ", elapsed)
-
-            else:
-
-                print("Pixel integrity error")
-
-        else:
-            print("Input must be a Nifti file (.nii or .nii.gz extensions)")
-
-        # After everything is finished, we can create the json side car
-        try:
-            repo = git.Repo(search_parent_directories=True)
-        except git.exc.InvalidGitRepositoryError:
-            # This in case that converter tool is not ran under the folder
-            print("No Git repository found in parent directories.")
-            repo = None
-        print("# Step 3. Creating json sidecar for the convertion #")
-
-        converter_sidecar = {}
-        # This depends on the OS system
-        author_name = os.getenv('USER') or os.getenv('USERNAME') or os.getenv('LOGNAME')
-        converter_sidecar['author'] = author_name if author_name else "Unknown User"
-        converter_sidecar['date'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        converter_sidecar['script'] = str(Path(os.path.abspath(__file__)).resolve())
-        converter_sidecar['command'] = command
-        if repo:
-            converter_sidecar['script source'] = repo.remotes.origin.url
-            converter_sidecar['script commit hash'] = repo.head.object.hexsha
-        else:
-            converter_sidecar['script source'] = "tissue_to_MR"
-            converter_sidecar['script commit hash'] = "check with git status"
-
-        json_out_name = output_file.replace(".nii.gz", ".json")
-        json_out_path = os.path.join("output", json_out_name)
-        print(json_out_path)
-        if os.path.exists(json_out_path):
-            print("Json sidecar found, overwritting ...")
-            os.remove(json_out_path)
-
-        with open(json_out_path, 'w', encoding='utf-8') as f:
-            json.dump(converter_sidecar, f, ensure_ascii=False, indent=4)
 
 #my_commands.add_command(converter)
 #if __name__ == "__main__":

--- a/tissue2mrprop/conventions.py
+++ b/tissue2mrprop/conventions.py
@@ -21,6 +21,8 @@ CANONICAL_ID_TO_NAME = {
     102: "organ",
     107: "tr_cartilage",
     113: "tr_lumen",
+    128: "teeth",
+    141: "braces", # Braces made out of: Stainless Steel
     196: "sc_wm",
     264: "fat",
     289: "sc_csf",

--- a/tissue2mrprop/conventions.py
+++ b/tissue2mrprop/conventions.py
@@ -1,0 +1,28 @@
+
+
+CANONICAL_ID_TO_NAME = {
+    0:   "air",
+    1:   "heart",
+    2:   "liver",
+    4:   "kidney",
+    5:   "brain",
+    6:   "spleen",
+    7:   "cartilage",
+    9:   "muscle",
+    10:  "bone",
+    11:  "v_bone",
+    12:  "lungs",
+    13:  "trachea",
+    14:  "spinal_cord",
+    18:  "esophagus",
+    19:  "gland",
+    100: "extra",
+    101: "water",
+    102: "organ",
+    107: "tr_cartilage",
+    113: "tr_lumen",
+    196: "sc_wm",
+    264: "fat",
+    289: "sc_csf",
+    324: "sc_gm",
+}

--- a/tissue2mrprop/conventions.py
+++ b/tissue2mrprop/conventions.py
@@ -21,6 +21,8 @@ CANONICAL_ID_TO_NAME = {
     102: "organ",
     107: "tr_cartilage",
     113: "tr_lumen",
+    117: "sinus",
+    119: "ear_canal",
     128: "teeth",
     141: "braces", # Braces made out of: Stainless Steel
     196: "sc_wm",

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -51,6 +51,8 @@ class SegmentationLabel:
             "v_bone": [None, 618.5, 80.685, 40.3, 40],
             "lungs": [None, 1400, 35.5, 1.62, 15],
             "trachea": [None, 1100, 40, 12, 5],
+            "tr_cartilage":[None, 1201, 43.225, 26.04, 70],
+            "tr_lumen": [None, 0.01, 0.01, 0.01, 0.01],
             "air": [None, 0.01, 0.01, 0.01, 0.01],
 
             "extra": [None, 800, 50, 35, 50],  # Mostly blood carriers or muscle (high water content)

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -126,15 +126,18 @@ class SegmentationLabel:
             "brain": [79.80, 0.829, 59.8, 0.972],  # Considered cerebellum
             "muscle": [63.5, 0.719, 58.2, 0.77],
             "bone": [14.7, 0.0673, 13.4, 0.0825],  # Cortical
+            "v_bone": [14.7, 0.0673, 13.4, 0.0825],  # Same as Cortical bone for now
             "lungs": [29.5, 0.316, 24.8, 0.356],  # Using value of Inflated Lungs
             "trachea": [50.6, 0.559, 45.3, 0.61],
             "air": [1, 0, 1, 0],
             "spinal_cord": [44.1, 0.354, 36.9, 0.418],
+            "sc_wm": [44.1, 0.354, 36.9, 0.418], # Same as spinal cord for now
+            "sc_gm": [44.1, 0.354, 36.9, 0.418], # Same as spinal cord for now
             "sc_csf": [84.1, 2.14, 72.8, 2.22],
             "organ": [89.7, 0.852, 70.6, 1.02],  # Using Kidney as reference
             "sinus": [5.435, 0.0426, 4.48, 0.051],  # Considering healthy sinus is 95% air and 5% soft tissue
             "inter_vert_discs": [52.9, 0.488, 46.8, 0.552],  # Considered cartilage
-
+            "cartilage": [89.7, 0.852, 70.6, 1.02], # Using same as ORGAN label for now
             # For ds005616 we have the eyes label
             "skull": [14.7, 0.0673, 13.4, 0.0825], # Considered cortical bone
             "eyes": [84.1, 2.14, 72.8, 2.22],  # Which according to IT'IS foundation, can be considered as CSF
@@ -190,7 +193,7 @@ class SegmentationLabel:
 
         if name in self.relax_values.keys():
             self.name = name
-            self.sus = self.relax_values[name][0]
+            self.susceptibility = self.relax_values[name][0]
             self.T1_val = self.relax_values[name][1]
             self.T2_val = self.relax_values[name][2]
             self.T2star_val = self.relax_values[name][3]
@@ -204,7 +207,7 @@ class SegmentationLabel:
             self.cond7T = self.static_values_short[name][3]
 
         else:
-
+            print(f"Label ID {name} not found, check tool and version selected")
             self.name = name
             self.M0_val = 0
             self.T1_val = 0

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -72,7 +72,8 @@ class SegmentationLabel:
             "sinus": [-2, None, None, None, None],  # Not used in CT tool // missing values
             # Used in totalSeg_mr & compare fm
             "inter_vert_discs": [-9.055, 1201, 42, 26, 50],  # Same as cartilage
-
+            "braces": [1e5, None, None, None, None, None], # Stainless steel. Work from S.R2 A.V M.N.
+            "teeth": [-12, None, None, None, None, None], # Teeth
         }
 
         # Here we have Permittivity@3T, Conductivity@3T, Permittivity@7T, Conductivity@7T
@@ -117,11 +118,11 @@ class SegmentationLabel:
 
             "sinus": [],
             "inter_vert_discs": [],
+            "braces": [],
 
         }
 
         self.static_values_short = {
-
             "fat": [48.17, 0.52, 44.25, 0.562],  # We use avg_infiltrated(30%) + muscle (70%)
             "brain": [79.80, 0.829, 59.8, 0.972],  # Considered cerebellum
             "muscle": [63.5, 0.719, 58.2, 0.77],
@@ -186,7 +187,8 @@ class SegmentationLabel:
 
             "extra": 7.45,  # 14.91
 
-            "sinus": 4.26  # 9.53
+            "sinus": 4.26,  # 9.53
+            "braces": None
         }
 
     def set_name(self, name):

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -84,42 +84,6 @@ class SegmentationLabel:
         # Units of conductivity S/m
         self.static_values = {
             # Will eventually need to be completed, for now use short version until required
-            "fat": [],
-            "heart": [],
-            "liver": [],
-            "pancreas": [],
-            "kidney": [],
-            "brain": [],
-            "spleen": [],
-            "cartilage": [],
-            "bone_marrow": [],
-
-            "sc_wm": [],
-            "sc_gm": [],
-            "sc_csf": [],
-
-            "muscle": [],
-            "bone": [],
-            "v_bone": [],
-            "lungs": [],
-            "trachea": [],
-            "air": [],
-
-            "extra": [],
-
-            "spinal_cord": [],
-            "water": [],
-            "CSF": [],
-            "white_matter": [],
-            "gray_matter": [],
-            "SpinalCanal": [],
-            "esophagus": [],
-            "organ": [],
-            "gland": [],
-
-            "sinus": [],
-            "inter_vert_discs": [],
-            "braces": [],
 
         }
 
@@ -130,8 +94,9 @@ class SegmentationLabel:
             "bone": [14.7, 0.0673, 13.4, 0.0825],  # Cortical
             "v_bone": [14.7, 0.0673, 13.4, 0.0825],  # Same as Cortical bone for now
             "lungs": [29.5, 0.316, 24.8, 0.356],  # Using value of Inflated Lungs
-            "trachea": [50.6, 0.559, 45.3, 0.61],
+            "tr_lumen": [50.6, 0.559, 45.3, 0.61],
             "air": [1, 0, 1, 0],
+            "gland": [89.7, 0.852, 70.6, 1.02],  # Using same as organ for now
             "spinal_cord": [44.1, 0.354, 36.9, 0.418],
             "sc_wm": [44.1, 0.354, 36.9, 0.418], # Same as spinal cord for now
             "sc_gm": [44.1, 0.354, 36.9, 0.418], # Same as spinal cord for now
@@ -139,8 +104,7 @@ class SegmentationLabel:
             "organ": [89.7, 0.852, 70.6, 1.02],  # Using Kidney as reference
             "sinus": [5.435, 0.0426, 4.48, 0.051],  # Considering healthy sinus is 95% air and 5% soft tissue
             "ear_canal": [5.435, 0.0426, 4.48, 0.051], # Same as sinus
-            "inter_vert_discs": [52.9, 0.488, 46.8, 0.552],  # Considered cartilage
-            "cartilage": [89.7, 0.852, 70.6, 1.02], # Using same as ORGAN label for now
+            "cartilage": [52.9, 0.488, 46.8, 0.552],  # Considered cartilage and invertebral discs
             # For ds005616 we have the eyes label
             "skull": [14.7, 0.0673, 13.4, 0.0825], # Considered cortical bone
             "eyes": [84.1, 2.14, 72.8, 2.22],  # Which according to IT'IS foundation, can be considered as CSF
@@ -194,47 +158,24 @@ class SegmentationLabel:
         }
 
     def set_name(self, name):
+        self.name = name
 
         if name in self.relax_values.keys():
-            self.name = name
             self.susceptibility = self.relax_values[name][0]
             self.T1_val = self.relax_values[name][1]
             self.T2_val = self.relax_values[name][2]
             self.T2star_val = self.relax_values[name][3]
             self.PD_val = self.relax_values[name][4]
 
-        elif name in self.static_values_short.keys():
-            self.name = name
-            self.perm3T = self.static_values_short[name][0]
-            self.cond3T = self.static_values_short[name][1]
-            self.perm7T = self.static_values_short[name][2]
-            self.cond7T = self.static_values_short[name][3]
-
-        else:
-            print(f"Label ID {name} not found, check tool and version selected")
-            self.name = name
-            self.M0_val = 0
-            self.T1_val = 0
-            self.T2_val = 0
-            self.T2star_val = 0
-            self.PD_val = 0
-            self.susceptibility = 0
-
-    def set_static_name(self, name):
-
         if name in self.static_values_short.keys():
-            self.name = name
             self.perm3T = self.static_values_short[name][0]
             self.cond3T = self.static_values_short[name][1]
             self.perm7T = self.static_values_short[name][2]
             self.cond7T = self.static_values_short[name][3]
 
-        else:
-            self.name = name
-            self.perm3T = 0
-            self.cond3T = 0
-            self.perm7T = 0
-            self.cond7T = 0
+
+        if name not in self.relax_values and name not in self.static_values_short:
+            print(f"Label name {name} not found in relax or static dictionaries")
 
     def set_susceptibility(self, susceptibility):
         self.susceptibility = susceptibility

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -70,6 +70,7 @@ class SegmentationLabel:
             # There are some organs that don't have enough documentation on the literature to complete
             # the required values so an estimation is used for these:
             "sinus": [-2, None, None, None, None],  # Not used in CT tool // missing values
+            "ear_canal": [-2, None, None, None, None],
             # Used in totalSeg_mr & compare fm
             "inter_vert_discs": [-9.055, 1201, 42, 26, 50],  # Same as cartilage
             "braces": [1e5, None, None, None, None, None], # Stainless steel. Work from S.R2 A.V M.N.
@@ -137,6 +138,7 @@ class SegmentationLabel:
             "sc_csf": [84.1, 2.14, 72.8, 2.22],
             "organ": [89.7, 0.852, 70.6, 1.02],  # Using Kidney as reference
             "sinus": [5.435, 0.0426, 4.48, 0.051],  # Considering healthy sinus is 95% air and 5% soft tissue
+            "ear_canal": [5.435, 0.0426, 4.48, 0.051], # Same as sinus
             "inter_vert_discs": [52.9, 0.488, 46.8, 0.552],  # Considered cartilage
             "cartilage": [89.7, 0.852, 70.6, 1.02], # Using same as ORGAN label for now
             # For ds005616 we have the eyes label

--- a/tissue2mrprop/functions/label.py
+++ b/tissue2mrprop/functions/label.py
@@ -20,7 +20,7 @@ class SegmentationLabel:
         self.cond7T = None
 
         # Key is the name and value is ordered:
-        # M0, T1, T2, T2*, PD
+        # Chi, T1, T2, T2*, PD
         # M0 = C * PD, where C is a scaling factor
         # C represents smoothly-varying spatial modulation of the PD map
         # by the profile of the r. coil gain (B-)
@@ -32,47 +32,46 @@ class SegmentationLabel:
 
         self.relax_values = {
             # Official labels for the Whole Body phantom by S.R.
-            "fat": [None, 401.2, 129.3, 64.65, 20],
-            "heart": [None, 1215.67, 49.35, 25.195, 77],
-            "liver": [None, 798.75, 33, 18.82, 70],
-            "pancreas": [None, 797.55, 43.5, 21.1, 70],
-            "kidney": [None, 1338, 86.835, 57.55, 82],
-            "brain": [None, 1232.9, 82.9, 42.8, 74.5],
-            "spleen": [None, 1328, 60.9, 16.3, 75],
-            "cartilage": [None, 1201, 43.225, 26.04, 70],
-            "bone_marrow": [None, 586, 49, 24.5, 27],
+            "fat": [-8.92, 401.2, 129.3, 64.65, 20],
+            "heart": [-9.05, 1215.67, 49.35, 25.195, 77],
+            "liver": [-9.05, 798.75, 33, 18.82, 70],
+            "pancreas": [-9.05, 797.55, 43.5, 21.1, 70],
+            "kidney": [-9.05, 1338, 86.835, 57.55, 82],
+            "brain": [-9.05, 1232.9, 82.9, 42.8, 74.5],
+            "spleen": [-9.05, 1328, 60.9, 16.3, 75],
+            "cartilage": [-9.055, 1201, 43.225, 26.04, 70],
+            "bone_marrow": [-9.05, 586, 49, 24.5, 27],
 
-            "sc_wm": [None, 857, 73, 38.65, 70],
-            "sc_gm": [None, 983.5, 76, 44.4, 80],
-            "sc_csf": [None, 5128, 1419.84, 709.92, 100],
+            "sc_wm": [-9.083, 857, 73, 38.65, 70],
+            "sc_gm": [-9.03, 983.5, 76, 44.4, 80],
+            "sc_csf": [-9.05, 5128, 1419.84, 709.92, 100],
 
-            "muscle": [None, 1237.825, 36.1, 24.1, 45],
-            "bone": [None, 223, 0.39, 1.16, 18],
-            "v_bone": [None, 618.5, 80.685, 40.3, 40],
-            "lungs": [None, 1400, 35.5, 1.62, 15],
-            "trachea": [None, 1100, 40, 12, 5],
-            "tr_cartilage":[None, 1201, 43.225, 26.04, 70],
-            "tr_lumen": [None, 0.01, 0.01, 0.01, 0.01],
-            "air": [None, 0.01, 0.01, 0.01, 0.01],
+            "muscle": [-9.05, 1237.825, 36.1, 24.1, 45],
+            "bone": [-11, 223, 0.39, 1.16, 18],
+            "v_bone": [-9.7, 618.5, 80.685, 40.3, 40],
+            "lungs": [-2.36, 1400, 35.5, 1.62, 15],
+            "trachea": [0.196, 1100, 40, 12, 5],
+            "tr_cartilage":[-9.05, 1201, 43.225, 26.04, 70],
+            "tr_lumen": [0.196, 0.01, 0.01, 0.01, 0.01],
+            "air": [0.35, 0.01, 0.01, 0.01, 0.01],
 
-            "extra": [None, 800, 50, 35, 50],  # Mostly blood carriers or muscle (high water content)
+            "extra": [-9.05, 800, 50, 35, 50],  # Mostly blood carriers or muscle (high water content)
 
             # Other labels for other segmentation tools available :)
             # Literature review pending
-            "spinal_cord": [None, 936.5, 76.75, 40.07, 60],
-            "water": [None, 2500, 275, 275/2, 100],  # High M0 value
-            "CSF": [None, 1953, 275, 275/2, 100],  # High M0 t1 from ITIS
+            "spinal_cord": [-9.055, 936.5, 76.75, 40.07, 60],
+            "water": [-9.05, 2500, 275, 275/2, 100],  # High M0 value
+            "CSF": [-9.05, 1953, 275, 275/2, 100],  # High M0 t1 from ITIS
             "white_matter": [None, 887.7, 65.4, 35, 70],  # This is the brain WM
             "gray_matter": [None, 1446.1, 94.3, 48, 82],  # This is the brain GM
-            "SpinalCanal": [None, 993, 78, 78/2, 90],  #
-            "esophagus": [None, 1000, 32, 17, 45],  # Assuming trachea is almost 100% muscle
-            "organ": [None, 800, 40, 20, 65],  # Values similar to those from liver
-            "gland": [None, 1600, 72, 72/2, 80],  # Values from ITIS foundation for Salivary gland
+            "esophagus": [-9.05, 1000, 32, 17, 45],  # Assuming trachea is almost 100% muscle
+            "organ": [-9.05, 800, 40, 20, 65],  # Values similar to those from liver
+            "gland": [-9.05, 1600, 72, 72/2, 80],  # Values from ITIS foundation for Salivary gland
             # There are some organs that don't have enough documentation on the literature to complete
             # the required values so an estimation is used for these:
-            "sinus": [None, None, None, None, None],  # Not used in CT tool // missing values
+            "sinus": [-2, None, None, None, None],  # Not used in CT tool // missing values
             # Used in totalSeg_mr & compare fm
-            "inter_vert_discs": [None, 1201, 42, 26, 50],  # Same as cartilage
+            "inter_vert_discs": [-9.055, 1201, 42, 26, 50],  # Same as cartilage
 
         }
 
@@ -191,7 +190,7 @@ class SegmentationLabel:
 
         if name in self.relax_values.keys():
             self.name = name
-            self.M0_val = self.relax_values[name][0]
+            self.sus = self.relax_values[name][0]
             self.T1_val = self.relax_values[name][1]
             self.T2_val = self.relax_values[name][2]
             self.T2star_val = self.relax_values[name][3]
@@ -212,6 +211,7 @@ class SegmentationLabel:
             self.T2_val = 0
             self.T2star_val = 0
             self.PD_val = 0
+            self.susceptibility = 0
 
     def set_static_name(self, name):
 
@@ -230,7 +230,6 @@ class SegmentationLabel:
             self.cond7T = 0
 
     def set_susceptibility(self, susceptibility):
-
         self.susceptibility = susceptibility
 
     def set_M0_val(self, M0):

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -166,10 +166,26 @@ def return_dict_labels(tool, version, new_chi=None):
 
             dicc[196] = ("sc_wm", -9.083)
             dicc[324] = ("sc_gm", -9.03)
-            # Future implementation
-            # Currently manually segmentating resampled registered CT image
-            # to get WM/GM segmentation masks
+
             return dicc
+
+        if version == "mod3":
+            # This means it has CSF + Spinal Cord + WM/GM segmentation instead of Spina Canal
+            dicc[264] = ("fat", -8.92)
+            # dicc[256] = ("spinal_cord", -9.055)
+            # If labels are done correctly, spinalcord (as well as spinal canal #79)
+            # should not be really appearing and not needed to state values for them
+            # hence my comment on previous line.
+            dicc[289] = ("sc_csf", -9.05)
+
+            dicc[196] = ("sc_wm", -9.083)
+            dicc[324] = ("sc_gm", -9.03)
+            # Additional to this we add trachea_cartilage and trachea_lumen
+            dicc[170] = ("tr_cartilage", -9.055)
+            dicc[171] = ("tr_lumen", 0.27)  # Calculation done by S.R. following values from CRC Handbook
+            return dicc
+
+
 
     if tool == 'TotalSeg_MRI':
 

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -194,7 +194,7 @@ def new_return_dict_labels(tool, version, new_chi=None):
             dicc[324] = ("sc_gm", 324)
             # Additional to this we add trachea_cartilage and trachea_lumen
             dicc[170] = ("tr_cartilage", 107)
-            dicc[171] = ("tr_lumen", 111)
+            dicc[171] = ("tr_lumen", 113)
             return dicc
 
     elif tool  == "bracesTS":
@@ -364,192 +364,112 @@ def new_return_dict_labels(tool, version, new_chi=None):
             }
             return dicc_braces
 
-
-
-
-
-
-
-
-
-
-
-
-def return_dict_labels(tool, version, new_chi=None):
-
-
-
-
-
-
-
-
-
-    if tool == 'TotalSeg_MRI':
+    elif tool == 'TotalSeg_MRI':
 
         dicc = {
-            0: ("air", 0.35),
-            1: ("spleen", -9.05),
-            2: ("kidney", -9.05),  # kidney_right
-            3: ("kidney", -9.05),  # kidney_left
-            4: ("organ", -9.05),  # gallbladder
-            5: ("liver", -9.05),  # liver
-            6: ("organ", -9.05),  # stomach
-            7: ("organ", -9.05),  # pancreas
-            8: ("gland", -9.05),  # adrenal_gland_right
-            9: ("gland", -9.05),  # adrenal_gland_left
-            10: ("lungs", 0.2),  # lung_left
-            11: ("lungs", 0.2),  # lung_right
-            12: ("esophagus", -9.05),  # esophagus
-            13: ("organ", -9.05),  # small_bowel
-            14: ("organ", -9.05),  # duodenum
-            15: ("organ", -9.05),  # colon
-            16: ("organ", -9.05),  # urinary_bladder
-            17: ("organ", -9.05),  # prostate
-            18: ("bone", -9),  # sacrum
-            19: ("bone", -9),  # vertebrae
-            20: ("bone", -9),  # intervertebral_discs
-            21: ("spinal_cord", -9.055),  # spinal_cord
-            22: ("heart", -9.04),  # heart
-            23: ("extra", -9.04),  # aorta
-            24: ("extra", -9.04),  # inferior_vena_cava
-            25: ("extra", -9.04),  # portal_vein_and_splenic_vein
-            26: ("extra", -9.04),  # iliac_artery_left
-            27: ("extra", -9.04),  # iliac_artery_right
-            28: ("extra", -9.04),  # iliac_vena_left
-            29: ("extra", -9.04),  # iliac_vena_right
-            30: ("bone", -9),  # humerus_left
-            31: ("bone", -9),  # humerus_right
-            32: ("bone", -9),  # fibula
-            33: ("bone", -9),  # tibia
-            34: ("bone", -9),  # femur_left
-            35: ("bone", -9),  # femur_right
-            36: ("bone", -9),  # hip_left
-            37: ("bone", -9),  # hip_right
-            38: ("extra", -9.04),  # gluteus_maximus_left
-            39: ("extra", -9.04),  # gluteus_maximus_right
-            40: ("extra", -9.04),  # gluteus_medius_left
-            41: ("extra", -9.04),  # gluteus_medius_right
-            42: ("extra", -9.04),  # gluteus_minimus_left
-            43: ("extra", -9.04),  # gluteus_minimus_right
-            44: ("extra", -9.04),  # autochthon_left
-            45: ("extra", -9.04),  # autochthon_right
-            46: ("extra", -9.04),  # iliopsoas_left
-            47: ("extra", -9.04),  # iliopsoas_right
-            48: ("extra", -9.04),  # quadriceps_femoris_left
-            49: ("extra", -9.04),  # quadriceps_femoris_right
-            50: ("extra", -9.04),  # thigh_medial_compartment_left
-            51: ("extra", -9.04),  # thigh_medial_compartment_right
-            52: ("extra", -9.04),  # thigh_posterior_compartment_left
-            53: ("extra", -9.04),  # thigh_posterior_compartment_right
-            54: ("extra", -9.04),  # sartorius_left
-            55: ("extra", -9.04),  # sartorius_right
-            56: ("brain", -9.04)  # brain
+            0: ("air", 0),
+            1: ("spleen", 6),
+            2: ("kidney", 4),  # kidney_right
+            3: ("kidney", 4),  # kidney_left
+            4: ("organ", 100),  # gallbladder
+            5: ("liver", 2),  # liver
+            6: ("organ", 100),  # stomach
+            7: ("organ", 100),  # pancreas
+            8: ("gland", 19),  # adrenal_gland_right
+            9: ("gland", 19),  # adrenal_gland_left
+            10: ("lungs", 12),  # lung_left
+            11: ("lungs", 12),  # lung_right
+            12: ("esophagus", 18),  # esophagus
+            13: ("organ", 100),  # small_bowel
+            14: ("organ", 100),  # duodenum
+            15: ("organ", 100),  # colon
+            16: ("organ", 100),  # urinary_bladder
+            17: ("organ", 100),  # prostate
+            18: ("bone", 10),  # sacrum
+            19: ("bone", 10),  # vertebrae
+            20: ("bone", 10),  # intervertebral_discs
+            21: ("spinal_cord", 14),  # spinal_cord
+            22: ("heart", 1),  # heart
+            23: ("extra", 100),  # aorta
+            24: ("extra", 100),  # inferior_vena_cava
+            25: ("extra", 100),  # portal_vein_and_splenic_vein
+            26: ("extra", 100),  # iliac_artery_left
+            27: ("extra", 100),  # iliac_artery_right
+            28: ("extra", 100),  # iliac_vena_left
+            29: ("extra", 100),  # iliac_vena_right
+            30: ("bone", 10),  # humerus_left
+            31: ("bone", 10),  # humerus_right
+            32: ("bone", 10),  # fibula
+            33: ("bone", 10),  # tibia
+            34: ("bone", 10),  # femur_left
+            35: ("bone", 10),  # femur_right
+            36: ("bone", 10),  # hip_left
+            37: ("bone", 10),  # hip_right
+            38: ("extra", 100),  # gluteus_maximus_left
+            39: ("extra", 100),  # gluteus_maximus_right
+            40: ("extra", 100),  # gluteus_medius_left
+            41: ("extra", 100),  # gluteus_medius_right
+            42: ("extra", 100),  # gluteus_minimus_left
+            43: ("extra", 100),  # gluteus_minimus_right
+            44: ("extra", 100),  # autochthon_left
+            45: ("extra", 100),  # autochthon_right
+            46: ("extra", 100),  # iliopsoas_left
+            47: ("extra", 100),  # iliopsoas_right
+            48: ("extra", 100),  # quadriceps_femoris_left
+            49: ("extra", 100),  # quadriceps_femoris_right
+            50: ("extra", 100),  # thigh_medial_compartment_left
+            51: ("extra", 100),  # thigh_medial_compartment_right
+            52: ("extra", 100),  # thigh_posterior_compartment_left
+            53: ("extra", 100),  # thigh_posterior_compartment_right
+            54: ("extra", 100),  # sartorius_left
+            55: ("extra", 100),  # sartorius_right
+            56: ("brain", 5)  # brain
         }
 
         if version == 'v1':
             return dicc
 
-        if version == 'mod0':
-            # Adding similar to CT case
-            # Adds labels with "head"
-            dicc[145] = ("head", -8.97)
-            dicc[169] = ("torso",-8.97)
-            dicc[101] = ('bone', -9)
-            return dicc
-
-    if tool == 'ProCord_MRI':
-        pass
-
-    if tool == "charles":
+    elif tool == "charles":
 
         dicc = {
 
-            0: ("air", 0.35),  # background
-            1: ("water", -9.05),  # body
-            2: ("air", 0.35),  # sinus
-            3: ("air", 0.35),  # ear_canal
-            4: ("trachea", 0.2),  # trachea
-            5: ("lung", 0.2),  # lung_left
-            6: ("lung", 0.2),  # lung_right
-            7: ("bone", -11.5),  # skull
-            8: ("water", -9.05),  # eyes
-            9: ("bone", -11.5),  # vertebrates
-            10: ("cartilage", -9.055),  # discs
+            0: ("air", 0),  # background
+            1: ("water", 100),  # body
+            2: ("sinus", 117),  # sinus
+            3: ("ear_canal", 119),  # ear_canal
+            4: ("tr_lumen", 113),  # trachea
+            5: ("lung", 12),  # lung_left
+            6: ("lung", 12),  # lung_right
+            7: ("bone", 10),  # skull
+            8: ("water", 100),  # eyes
+            9: ("v_bone", 11),  # vertebrates
+            10: ("cartilage", 7),  # discs
         }
         if version == 'v1':
             return dicc
 
-    if tool == "compare_fm":
+    elif tool == "compare_fm":
         # This project aims to simulate only 3 different tissue types
-        # Bones, soft tisssue and air
+        # Bones, soft tissue and air
         #
         # Some values were changed for ISMRM abstract. More precise values may be implemented later
         dicc = {
-            0: ("air", 0.35), # Outside of the body
-            2: ("fat", -9.05), # Water and muscle surrounding the labels ## Before -9.032
-            3: ("bone", -11), # Spine
-            5: ("inter_vert_discs", -9.05),
-            7: ("lungs", -4.2), # magical air inside lungs and esophagus
-            8: ("trachea", -4.2), # Air in the trachea
-            10: ("organ", -9.05), # Susceptibility of water
-            12: ("muscle", -9.05), # Muscle has slightly different value than water
-            15: ("sinus", -2),
-            23: ("brain", -9.04),  # Brain from Samseg
-            25: ("skull", -11),  # Skull from Samseg with manual correction in Slicer
-            256: ("spinal_cord",-9.055), # Soft tissue for this project
-            289:("sc_csf,",-9.055) # Same as 256 for this project, might change later
+            0: ("air", 0),  # Outside the body
+            2: ("fat", 264),  # Water and muscle surrounding the labels ## Before -9.032
+            3: ("bone", 11),  # Spine
+            5: ("cartilage", 7),  # Intervertebral discs
+            7: ("lungs", 12),  # magical air inside lungs and esophagus
+            8: ("tr_lumen", 113),  # Air in the trachea
+            10: ("organ", 100),  # Susceptibility of water
+            12: ("muscle", 9),  # Muscle has slightly different value than water
+            15: ("sinus", 117),
+            23: ("brain", 5),   # Brain from Samseg
+            25: ("skull", 10),   # Skull from Samseg with manual correction in Slicer
+            256: ("spinal_cord", 14),  # Soft tissue for this project
+            289:("sc_csf,",289)  # Same as 256 for this project, might change later
         }
         if version == 'mod0':
             return dicc
-
-        if version == "dyn":
-            # This is for dynamically changing the susceptiblity values
-            # Only changing the value of air in lungs and trachea
-
-            lst1 = list(dicc[7])
-            lst2 = list(dicc[8])
-            lst1[1] = new_chi
-            lst2[1] = new_chi
-            dicc[7] = tuple(lst1)
-            dicc[8] = tuple(lst2)
-            print("Changing susceptibility of air to: ", new_chi)
-            return dicc
-
-        if version == 'mod_PAM50':
-            dicc2 = {
-            0 : ("air", 0.35), # Air surrounding the body
-            2 : ("fat", -9.05), # Water and muscle surrounding the labels
-            3 : ("bone", -11), #
-            5 : ("inter_vert_discs", -9.055),
-            7 : ("lungs", -4.2), # magical air inside lungs and esophagus
-            8 : ("trachea", -4.2), # Air in the trachea
-            10 : ("organ", -9.05), # Susceptibility of water
-            12: ("muscle", -9.05), # Muscle has slightly different value than water
-            15 : ("sinus", -2), # Air in the sinuses and ear canal
-            256: ("spinal cord",-9.05) # Soft tissue for this project
-            }
-            return dicc2
-
-        if version == 'ds005616':
-            dicc3 = {
-                0: ("air", 0.35),  # Air surrounding the body
-                1: ("fat", -9.05),
-                2: ("sinus", -2),
-                3: ("sinus",-2),
-                4: ("trachea",-2.3),
-                5: ("lungs",-2.3),
-                6: ("lungs",-2.3),
-                56: ("brain",-9.04),
-                60: ("eyes",-9.05),
-                91: ("skull",-11),
-                92: ("bone",-11),
-                93: ("inter_vert_discs",-9.055),
-                100:("spinal_cord",-9.05)
-
-            }
-            return dicc3
-
 
     else:
         print("This tool hasn't been implemented yet.")

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -197,187 +197,191 @@ def new_return_dict_labels(tool, version, new_chi=None):
             dicc[171] = ("tr_lumen", 111)
             return dicc
 
+    elif tool  == "bracesTS":
+        if version == "v1":
+            # Unmerged labels - same values as v2
+            dicc_braces = {  # ICPR 143
+                0: ("air", 0),  # Air surrounding the body
+                1: ("kidney", 4),  # Adrenal, left
+                2: ("kidney", 4),  # Adrenal, right
+                3: ("extra", 100),  # Anterior nasal passage (ET1)
+                4: ("extra", 100),  # Posterior nasal passage (ET2)
+                5: ("extra", 100),  # Oral mucosa, tongue
+                6: ("extra", 100),  # Oral mucosa, lips and cheeks
+                7: ("tr_cartilage", 107),  # !!!!! only the tissue, air is separate
+                8: ("extra", 100),  # !!!!! Bronchi? only the tissue air is separete
+                9: ("extra", 100),  # Blood vessels, head
+                10: ("extra", 100),  # Blood vessels, trunk
+                11: ("extra", 100),  # Blood vessels, arms
+                12: ("extra", 100),  # Blood vessels, legs
+                13: ("bone", 10),  # Humeri, upper half, cortical
+                14: ("bone", 10),  # Humeri, upper half, spongiosa
+                15: ("bone", 10),  # Humeri, upper half, medullary cavity
+                16: ("bone", 10),  # Humeri, lower half, cortical
+                17: ("bone", 10),  # Humeri, lower half, spongiosa
+                18: ("bone", 10),  # Humeri, lower half, medullary cavity
+                19: ("bone", 10),  # Ulnae and radii, cortical
+                20: ("bone", 10),  # Ulnae and radii, spongiosa
+                21: ("bone", 10),  # Ulnae and radii, medullary cavity
+                22: ("bone", 10),  # Wrists and hand bones, cortical
+                23: ("bone", 10),  # Wrists and hand bones, spongiosa
+                24: ("bone", 10),  # Clavicles, cortical
+                25: ("bone", 10),  # Clavicles, spongiosa
+                26: ("bone", 10),  # Cranium, cortical
+                27: ("bone", 10),  # Cranium, spongiosa
+                28: ("bone", 10),  # Femora, upper half, cortical
+                29: ("bone", 10),  # Femora, upper half, spongiosa
+                30: ("bone", 10),  # Femora, upper half, medullary cavity
+                31: ("bone", 10),  # Femora, lower half, cortical
+                32: ("bone", 10),  # Femora, lower half, spongiosa
+                33: ("bone", 10),  # Femora, lower half, medullary cavity
+                34: ("bone", 10),  # Tibiae, fibulae and patellae, cortical
+                35: ("bone", 10),  # Tibiae, fibulae and patellae, spongiosa
+                36: ("bone", 10),  # Tibiae, fibulae and patellae, medullary cavity
+                37: ("bone", 10),  # Ankles and foot bones, cortical
+                38: ("bone", 10),  # Ankles and foot bones, spongiosa
+                39: ("bone", 10),  # Mandible, cortical
+                40: ("bone", 10),  # Mandible, spongiosa
+                41: ("bone", 10),  # Pelvis, cortical
+                42: ("bone", 10),  # Pelvis, spongiosa
+                43: ("bone", 10),  # Ribs, cortical
+                44: ("bone", 10),  # Ribs, spongiosa
+                45: ("bone", 10),  # Scapulae, cortical
+                46: ("bone", 10),  # Scapulae, spongiosa
+                47: ("v_bone", 11),  # Cervical spine, cortical
+                48: ("v_bone", 11),  # Cervical spine, spongiosa
+                49: ("v_bone", 11),  # Thoracic spine, cortical
+                50: ("v_bone", 11),  # Thoracic spine, spongiosa
+                51: ("v_bone", 11),  # Lumbar spine, cortical
+                52: ("v_bone", 11),  # Lumbar spine, spongiosa
+                53: ("v_bone", 11),  # Sacrum, cortical
+                54: ("v_bone", 11),  # Sacrum, spongiosa
+                55: ("bone", 10),  # Sternum, cortical
+                56: ("bone", 10),  # Sternum, spongiosa
+                57: ("cartilage", 7),  # Cartilage, head
+                58: ("cartilage", 7),  # Cartilage, trunk
+                59: ("cartilage", 7),  # Cartilage, arms
+                60: ("cartilage", 7),  # Cartilage, legs
+                61: ("brain", 5),
+                62: ("fat", 264),  # Breast, left, adipose tissue (review mr props)
+                63: ("fat", 264),  # Breast, left, glandular tissue (review mr props)
+                64: ("fat", 264),  # Breast, right, adipose tissue
+                65: ("fat", 264),  # Breast, right, glandular tissue
+                66: ("extra", 100),  # Eye lense, left
+                67: ("extra", 100),  # Eye bulb, left
+                68: ("extra", 100),  # Eye lense, right
+                69: ("extra", 100),  # Eye bulb, right
+                70: ("extra", 100),  # Gall bladder wall
+                71: ("extra", 100),  # Gall bladder contents
+                72: ("extra", 100),  # Stomach wall
+                73: ("extra", 100),  # Stomach contents
+                74: ("extra", 100),  # Small intestine wall
+                75: ("tr_lumen", 113),  # Small intestine contents
+                76: ("extra", 100),  # Ascending colon wall
+                77: ("extra", 100),  # Ascending colon contents
+                78: ("extra", 100),  # Transverse colon wall, right
+                79: ("extra", 100),  # Transverse colon contents, right
+                80: ("extra", 100),  # Transverse colon wall, left
+                81: ("extra", 100),  # Transverse colon contents, left
+                82: ("extra", 100),  # Descending colon wall
+                83: ("extra", 100),  # Descending colon contents
+                84: ("extra", 100),  # Sigmoid colon wall
+                85: ("extra", -100),  # Sigmoid colon contents
+                86: ("extra", 100),  # Rectum wall
+                87: ("heart", 1),  # Heart wall
+                88: ("heart", 1),  # Heart contents (blood)
+                89: ("kidney", 4),  # Kidney, left, cortex
+                90: ("kidney", 4),  # Kidney, left, medulla
+                91: ("kidney", 4),  # Kidney, left, pelvis
+                92: ("kidney", 4),  # Kidney, right, cortex
+                93: ("kidney", 4),  # Kidney, right, medulla
+                94: ("kidney", 4),  # Kidney, right, pelvis
+                95: ("liver", 2),
+                96: ("lungs", 12),  # Lung, left, blood
+                97: ("lungs", 12),  # Lung, left, tissue
+                98: ("lungs", 12),  # Lung, right, blood
+                99: ("lungs", 12),  # Lung, right, tissue
+                100: ("extra", 100),  # Lymphatic nodes, extrathoracic airways
+                101: ("extra", 100),  # Lymphatic nodes, thoracic airways
+                102: ("extra", 100),  # Lymphatic nodes, head
+                103: ("extra", 100),  # Lymphatic nodes, trunk
+                104: ("extra", 100),  # Lymphatic nodes, arms
+                105: ("extra", 100),  # Lymphatic nodes, legs
+                106: ("muscle", 9),  # Muscle, head
+                107: ("muscle", 9),  # Muscle, trunk
+                108: ("muscle", 9),  # Muscle, arms
+                109: ("muscle", 9),  # Muscle, legs
+                110: ("esophagus", 18),
+                111: ("extra", 100),  # Ovary, left
+                112: ("extra", 100),  # Ovary, right
+                113: ("extra", 100),
+                114: ("gland", 19),  # Pituitary glab
+                115: ("extra", 100),  # Prostate
+                116: ("extra", 100),  # Residual tissue, head
+                117: ("extra", 100),  # Residual tissue, trunk
+                118: ("extra", 100),  # Residual tissue, arms
+                119: ("extra", 100),  # Residual tissue, legs
+                120: ("gland", 19),  # Salivary glands, left
+                121: ("gland", 19),  # Salivary glands, right
+                122: ("fat", 264),  # Skin, head
+                123: ("fat", 264),  # Skin, trunk
+                124: ("fat", 264),  # Skin, arms
+                125: ("fat", 264),  # Skin, legs
+                126: ("spinal_cord", 14),
+                127: ("spleen", 6),
+                128: ("teeth", 128),  # Teeth
+                129: ("extra", 100),  # Testis, left
+                130: ("extra", 100),  # Testis, right
+                131: ("extra", 100),  #
+                132: ("gland", 19),  # Thyroid
+                133: ("extra", 100),  # Tongue (inner part)
+                134: ("extra", 100),  # Tonsils
+                135: ("extra", 100),  # Ureter, left
+                136: ("extra", 100),  # Ureter, right
+                137: ("extra", 100),  # Urinary bladder wall
+                138: ("water", 101),  # Urinary bladder contents
+                139: ("extra", 100),  # Uterus
+                140: ("air", 0),  # Air inside body
+                141: ("braces", 141)  # Stainless stell 316L
+            }
+            return dicc_braces
+
+        if version == 'v2':
+            # Merged labels
+            dicc_braces = {  # for scan with merged labels
+                0: ("air", 0.35),  # Air surrounding the body
+                1: ("bone", -11.1),
+                2: ("Teeth", -10),
+                3: ("Cervical spine", -9.7),
+                4: ("cartilage", -9.055),
+                5: ("watery tissue", -9.05),
+                6: ("extra (blood/muscle)", -9.04),
+                7: ("muscle", -9.03),
+                8: ("fat", -8.92),
+                9: ("lungs", -0.27),
+                10: ("Air", 0.35),
+                11: ("braces", 900),
+            }
+            return dicc_braces
+
+
+
+
+
+
+
+
+
+
+
 
 def return_dict_labels(tool, version, new_chi=None):
 
-    if tool == "TotalSeg_CT":
 
-        # Using total segmentator we use follow their list for 117 labels
-        # and group them up based on their effect to the B0 map impact
-        # link: https://github.com/wasserth/TotalSegmentator/blob/master/totalsegmentator/map_to_binary.py
 
-        # Baseline dictionary for Total Segmentator CT
-        # id : name, susceptibility_value
 
-        dicc= {
 
-            0: ("air", 0.35),
-            1: ("spleen",-9.05),
-            2: ("kidney",-9.05), # kidney_right
-            3: ("kidney",-9.05), # kidney_left
-            4: ("organ",-9.05), # gallbladder
-            5: ("liver",-9.05), # liver
-            6: ("organ",-9.05), # stomach
-            7: ("organ",-9.05), # pancreas
-            8: ("gland",-9.05), # adrenal gland left
-            9: ("gland",-9.05), # adrenal_gland_left
-            # Updated as of August 2025 (compare_fm + chi_opt)
-            10: ("lungs",-2.41), # lung_upper_lobe_left
-            11: ("lungs",-2.41), # lung_lower_lobe_left
-            12: ("lungs",-2.41), # lung_upper_lobe_right
-            13: ("lungs",-2.41), # lung_middle_lobe_right
-            14: ("lungs",-2.41), # lung_lower_lobe_right
-            15: ("esophagus", -9.05),
-            16: ("trachea", 0.2),
-            #
-            17: ("gland",-9.05), # thyroid_gland
-            18: ("organ",-9.05), # small_bowel
-            19: ("organ",-9.05), # duodenum
-            20: ("organ",-9.05), # colon
-            21: ("organ",-9.05), # urinary_bladder
-            22: ("organ",-9.05), # prostate
-            23: ("kidney",-9.05), # kidney_cyst_left
-            24: ("kidney",-9.05), # kidney_cyst_right
-            25: ("v_bone",-9.7), # sacrum
-            26: ("v_bone",-9.7), #vertebrae_S1
-            27: ("v_bone",-9.7), # vertebrae_L5
-            28: ("v_bone",-9.7), # vertebrae_L4
-            29: ("v_bone",-9.7), # vertebrae_L3
-            30: ("v_bone",-9.7), # vertebrae_L2
-            31: ("v_bone",-9.7), # vertebrae_L1
-            32: ("v_bone",-9.7), # vertebrae_T12
-            33: ("v_bone",-9.7), # vertebrae_T11
-            34: ("v_bone",-9.7), # vertebrae_T10
-            35: ("v_bone",-9.7), # vertebrae_T9
-            36: ("v_bone",-9.7), # vertebrae_T8
-            37: ("v_bone",-9.7), # vertebrae_T7
-            38: ("v_bone",-9.7), # vertebrae_T6
-            39: ("v_bone",-9.7), #vertebrae_T5
-            40: ("v_bone",-9.7), # vertebrae_T4
-            41: ("v_bone",-9.7), #vertebrae_T3
-            42: ("v_bone",-9.7), # vertebrae_T2
-            43: ("v_bone",-9.7), # vertebrae_T1
-            44: ("v_bone",-9.7), # vertebrae_C7
-            45: ("v_bone",-9.7), # vertebrae_C6
-            46: ("v_bone",-9.7), # vertebrae_C5
-            47: ("v_bone",-9.7), # vertebrae_C4
-            48: ("v_bone",-9.7), # vertebrae_C3
-            49: ("v_bone",-9.7), # vertebrae_C2
-            50: ("v_bone",-9.7), # vertebrae_C1
-            51: ("heart",-9.05), # heart
-            52: ("extra",-9.05), # aorta
-            53: ("extra",-9.04), # pulmonary_vein
-            54: ("extra",-9.04), # brachiocephalic_trunk
-            55: ("extra",-9.04), # subclavian_artery_right
-            56: ("extra",-9.04), # subclavian_artery_left
-            57: ("extra",-9.04), # common_carotid_artery_right
-            58: ("extra",-9.04), # common_carotid_artery_left
-            59: ("extra",-9.04), # brachiocephalic_vein_left
-            60: ("extra",-9.04), # brachiocephalic_vein_right
-            61: ("extra",-9.04), # atrial_appendage_left
-            62: ("extra",-9.04), # superior_vena_cava
-            63: ("extra",-9.04), # inferior_vena_cava
-            64: ("extra",-9.04), # portal_vein_and_splenic_vein
-            65: ("extra",-9.04), # iliac_artery_left
-            66: ("extra",-9.04), # iliac_artery_right
-            67: ("extra",-9.04), # iliac_vena_left
-            68: ("extra",-9.04), # iliac_vena_right
-            69: ("bone",-11.1), # humerus_left
-            70: ("bone",-11.1), # humerus_right
-            71: ("bone",-11.1), # scapula_left
-            72: ("bone",-11.1), # scapula_right
-            73: ("bone",-11.1), # clavicula_left
-            74: ("bone",-11.1), # clavicula_right
-            75: ("bone",-11.1), # femur_left
-            76: ("bone",-11.1), # femur_right
-            77: ("bone",-11.1), # hip_left
-            78: ("bone",-11.1), # hip_right
-            79: ("SpinalCanal",-9.055), # Spinal Canal (from Total Seg)
-            80: ("muscle",-9.03), # gluteus_maximus_left
-            81: ("muscle",-9.03), # gluteus_maximus_right
-            82: ("muscle",-9.03), # gluteus_medius_left
-            83: ("muscle",-9.03), # gluteus_medius_right
-            84: ("muscle",-9.03), # gluteus_minimus_left
-            85: ("muscle",-9.03), # gluteus_minimus_right
-            86: ("muscle",-9.03), # autochthon_left
-            87: ("muscle",-9.03), # autochthon_right
-            88: ("muscle",-9.03), # iliopsoas_left
-            89: ("muscle",-9.03), # iliopsoas_right
-            90: ("brain",-9.05), # brain
-            91: ("bone",-11.1), # skull
-            92: ("bone",-11.1), # rib_left_1
-            93: ("bone",-11.1), # rib_left_2
-            94: ("bone",-11.1), # rib_left_3
-            95: ("bone",-11.1), # rib_left_4
-            96: ("bone",-11.1), # rib_left_5
-            97: ("bone",-11.1), # rib_left_6
-            98: ("bone",-11.1), # rib_left_7
-            99: ("bone",-11.1), # rib_left_8
-            100: ("bone",-11.1), # rib_left_9
-            101: ("bone",-11.1), # rib_left_10
-            102: ("bone",-11.1), # rib_left_11
-            103: ("bone",-11.1), # rib_left_12
-            104: ("bone",-11.1), # rib_right_1
-            105: ("bone",-11.1), # rib_right_2
-            106: ("bone",-11.1), # rib_right_3
-            107: ("bone",-11.1), # rib_right_4
-            108: ("bone",-11.1), # rib_right_5
-            109: ("bone",-11.1), # rib_right_6
-            110: ("bone",-11.1), # rib_right_7
-            111: ("bone",-11.1), # rib_right_8
-            112: ("bone",-11.1), # rib_right_9
-            113: ("bone",-11.1), # rib_right_10
-            114: ("bone",-11.1), # rib_right_11
-            115: ("bone",-11.1), # rib_right_12
-            116: ("bone",-11.1), # sternum
-            117: ("cartilage",-9.055) # costal_cartilages
-        }
 
-        if version == "v2":
-            return dicc
-
-        if version =="mod0":
-            # This means it has labels + fat = Whole body
-            dicc[264]=("fat",-8.92)
-            return dicc
-
-        if version =="mod1":
-            # This means its Whole body + Spinal Cord CSF to differentiate Spinal Canal
-            # from spinal cord
-            dicc[264]=("fat",-8.92)
-            dicc[256]=("spinal_cord",-9.055)
-            dicc[289]=("sc_csf",-9.05)
-            return dicc
-
-        if version=="mod2":
-            # This means it has CSF + Spinal Cord + WM/GM segmentation instead of Spina Canal
-            dicc[264]=("fat",-8.92)
-            #dicc[256] = ("spinal_cord", -9.055)
-            # If labels are done correctly, spinalcord (as well as spinal canal #79)
-            # should not be really appearing and not needed to state values for them
-            # hence my comment on previous line.
-            dicc[289] = ("sc_csf", -9.05)
-
-            dicc[196] = ("sc_wm", -9.083)
-            dicc[324] = ("sc_gm", -9.03)
-
-            return dicc
-
-        if version == "mod3":
-            # This means it has CSF + Spinal Cord + WM/GM segmentation instead of Spina Canal
-            dicc[264] = ("fat", -8.92)
-            # dicc[256] = ("spinal_cord", -9.055)
-            # If labels are done correctly, spinalcord (as well as spinal canal #79)
-            # should not be really appearing and not needed to state values for them
-            # hence my comment on previous line.
-            dicc[289] = ("sc_csf", -9.05)
-
-            dicc[196] = ("sc_wm", -9.083)
-            dicc[324] = ("sc_gm", -9.03)
-            # Additional to this we add trachea_cartilage and trachea_lumen
-            dicc[170] = ("tr_cartilage", -9.055)
-            dicc[171] = ("tr_lumen", 0.196)  # Calculation done by S.R. following values from CRC Handbook and chi-opt
-            return dicc
 
 
 
@@ -546,171 +550,6 @@ def return_dict_labels(tool, version, new_chi=None):
             }
             return dicc3
 
-    if tool  == "bracesTS":
-        if version == "v1":
-            # Unmerged labels - same values as v2
-            dicc_braces = {  # ICPR 143
-                0: ("air", 0.35),  # Air surrounding the body
-                1: ("kidney", -9.05),  # Adrenal, left
-                2: ("kidney", -9.05),  # Adrenal, right
-                3: ("Anterior nasal passage", -9.05),  # Anterior nasal passage (ET1)
-                4: ("Posterior nasal passage", -9.05),  # Posterior nasal passage (ET2)
-                5: ("Oral mucosa", -9.05),  # Oral mucosa, tongue
-                6: ("Oral mucosa", -9.05),  # Oral mucosa, lips and cheeks
-                7: ("trachea", -9.055),  # !!!!! only the tissue, air is separate
-                8: ("Bronchi", -9.05),  # !!!!! only the tissue air is separete
-                9: ("extra (blood/muscle)", -9.04),  # Blood vessels, head
-                10: ("extra (blood/muscle)", -9.04),  # Blood vessels, trunk
-                11: ("extra (blood/muscle)", -9.04),  # Blood vessels, arms
-                12: ("extra (blood/muscle)", -9.04),  # Blood vessels, legs
-                13: ("bone", -11.1),  # Humeri, upper half, cortical
-                14: ("bone", -11.1),  # Humeri, upper half, spongiosa
-                15: ("bone", -11.1),  # Humeri, upper half, medullary cavity
-                16: ("bone", -11.1),  # Humeri, lower half, cortical
-                17: ("bone", -11.1),  # Humeri, lower half, spongiosa
-                18: ("bone", -11.1),  # Humeri, lower half, medullary cavity
-                19: ("bone", -11.1),  # Ulnae and radii, cortical
-                20: ("bone", -11.1),  # Ulnae and radii, spongiosa
-                21: ("bone", -11.1),  # Ulnae and radii, medullary cavity
-                22: ("bone", -11.1),  # Wrists and hand bones, cortical
-                23: ("bone", -11.1),  # Wrists and hand bones, spongiosa
-                24: ("bone", -11.1),  # Clavicles, cortical
-                25: ("bone", -11.1),  # Clavicles, spongiosa
-                26: ("bone", -11.1),  # Cranium, cortical
-                27: ("bone", -11.1),  # Cranium, spongiosa
-                28: ("bone", -11.1),  # Femora, upper half, cortical
-                29: ("bone", -11.1),  # Femora, upper half, spongiosa
-                30: ("bone", -11.1),  # Femora, upper half, medullary cavity
-                31: ("bone", -11.1),  # Femora, lower half, cortical
-                32: ("bone", -11.1),  # Femora, lower half, spongiosa
-                33: ("bone", -11.1),  # Femora, lower half, medullary cavity
-                34: ("bone", -11.1),  # Tibiae, fibulae and patellae, cortical
-                35: ("bone", -11.1),  # Tibiae, fibulae and patellae, spongiosa
-                36: ("bone", -11.1),  # Tibiae, fibulae and patellae, medullary cavity
-                37: ("bone", -11.1),  # Ankles and foot bones, cortical
-                38: ("bone", -11.1),  # Ankles and foot bones, spongiosa
-                39: ("bone", -11.1),  # Mandible, cortical
-                40: ("bone", -11.1),  # Mandible, spongiosa
-                41: ("bone", -11.1),  # Pelvis, cortical
-                42: ("bone", -11.1),  # Pelvis, spongiosa
-                43: ("bone", -11.1),  # Ribs, cortical
-                44: ("bone", -11.1),  # Ribs, spongiosa
-                45: ("bone", -11.1),  # Scapulae, cortical
-                46: ("bone", -11.1),  # Scapulae, spongiosa
-                47: ("Cervical spine", -9.7),  # Cervical spine, cortical
-                48: ("Cervical spine", -9.7),  # Cervical spine, spongiosa
-                49: ("Thoracic spine", -9.7),  # Thoracic spine, cortical
-                50: ("Thoracic spine", -9.7),  # Thoracic spine, spongiosa
-                51: ("Lumbar spine", -9.7),  # Lumbar spine, cortical
-                52: ("Lumbar spine", -9.7),  # Lumbar spine, spongiosa
-                53: ("Sacrum", -9.7),  # Sacrum, cortical
-                54: ("Sacrum", -9.7),  # Sacrum, spongiosa
-                55: ("bone", -11.1),  # Sternum, cortical
-                56: ("bone", -11.1),  # Sternum, spongiosa
-                57: ("cartilage", -9.055),  # Cartilage, head
-                58: ("cartilage", -9.055),  # Cartilage, trunk
-                59: ("cartilage", -9.055),  # Cartilage, arms
-                60: ("cartilage", -9.055),  # Cartilage, legs
-                61: ("brain", -9.05),
-                62: ("fat", -8.92),  # Breast, left, adipose tissue
-                63: ("Breast", -9.05),  # Breast, left, glandular tissue
-                64: ("fat", -8.92),  # Breast, right, adipose tissue
-                65: ("Breast", -9.05),  # Breast, right, glandular tissue
-                66: ("Eye lens", -9.05),  # Eye lense, left
-                67: ("Eye bulb", -9.05),  # Eye bulb, left
-                68: ("Eye lens", -9.05),  # Eye lense, right
-                69: ("Eye bulb", -9.05),  # Eye bulb, right
-                70: ("Gall bladder", -9.05),  # Gall bladder wall
-                71: ("Gall bladder", -9.05),  # Gall bladder contents
-                72: ("Stomach", -9.05),  # Stomach wall
-                73: ("Stomach", -9.05),  # Stomach contents
-                74: ("Small intestine", -9.05),  # Small intestine wall
-                75: ("Small intestine", -9.05),  # Small intestine contents
-                76: ("Colon", -9.05),  # Ascending colon wall
-                77: ("Colon", -9.05),  # Ascending colon contents
-                78: ("Colon", -9.05),  # Transverse colon wall, right
-                79: ("Colon", -9.05),  # Transverse colon contents, right
-                80: ("Colon", -9.05),  # Transverse colon wall, left
-                81: ("Colon", -9.05),  # Transverse colon contents, left
-                82: ("Colon", -9.05),  # Descending colon wall
-                83: ("Colon", -9.05),  # Descending colon contents
-                84: ("Sigmoid colon", -9.05),  # Sigmoid colon wall
-                85: ("Sigmoid colon", -9.05),  # Sigmoid colon contents
-                86: ("Rectum", -9.05),  # Rectum wall
-                87: ("heart", -9.05),  # Heart wall
-                88: ("heart", -9.05),  # Heart contents (blood)
-                89: ("kidney", -9.05),  # Kidney, left, cortex
-                90: ("kidney", -9.05),  # Kidney, left, medulla
-                91: ("kidney", -9.05),  # Kidney, left, pelvis
-                92: ("kidney", -9.05),  # Kidney, right, cortex
-                93: ("kidney", -9.05),  # Kidney, right, medulla
-                94: ("kidney", -9.05),  # Kidney, right, pelvis
-                95: ("liver", -9.05),
-                96: ("lungs", -0.27),  # Lung, left, blood
-                97: ("lungs", -0.27),  # Lung, left, tissue
-                98: ("lungs", -0.27),  # Lung, right, blood
-                99: ("lungs", -0.27),  # Lung, right, tissue
-                100: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, extrathoracic airways
-                101: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, thoracic airways
-                102: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, head
-                103: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, trunk
-                104: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, arms
-                105: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, legs
-                106: ("muscle", -9.03),  # Muscle, head
-                107: ("muscle", -9.03),  # Muscle, trunk
-                108: ("muscle", -9.03),  # Muscle, arms
-                109: ("muscle", -9.03),  # Muscle, legs
-                110: ("esophagus", -9.05),
-                111: ("Ovary", -9.05),  # Ovary, left
-                112: ("Ovary", -9.05),  # Ovary, right
-                113: ("pancreas", -9.05),
-                114: ("Pituitary gland", -9.05),  #
-                115: ("Prostate", -9.05),  #
-                116: ("Residual tissue", -9.05),  # Residual tissue, head
-                117: ("Residual tissue", -9.05),  # Residual tissue, trunk
-                118: ("Residual tissue", -9.05),  # Residual tissue, arms
-                119: ("Residual tissue", -9.05),  # Residual tissue, legs
-                120: ("Salivary glands", -9.05),  # Salivary glands, left
-                121: ("Salivary glands", -9.05),  # Salivary glands, right
-                122: ("Skin", -8.92),  # Skin, head
-                123: ("Skin", -8.92),  # Skin, trunk
-                124: ("Skin", -8.92),  # Skin, arms
-                125: ("Skin", -8.92),  # Skin, legs
-                126: ("spinal_cord", -9.055),
-                127: ("spleen", -9.05),
-                128: ("Teeth", -10),  # Teeth
-                129: ("Testis", -9.05),  # Testis, left
-                130: ("Testis", -9.05),  # Testis, right
-                131: ("Thymus", -9.05),  #
-                132: ("Thyroid", -9.05),  #
-                133: ("Tongue", -9.05),  # Tongue (inner part)
-                134: ("Tonsils", -9.05),  #
-                135: ("Ureter", -9.05),  # Ureter, left
-                136: ("Ureter", -9.05),  # Ureter, right
-                137: ("Urinary bladder", -9.05),  # Urinary bladder wall
-                138: ("water", -9.05),  # Urinary bladder contents
-                139: ("Uterus", -9.05),  #
-                140: ("Air", 0.35),  # Air inside body
-                141: ("braces", 900)  # Stainless stell 316L
-            }
-            return dicc_braces
 
-        if version == 'v2':
-            # Merged labels
-            dicc_braces = {  # for scan with merged labels
-                0: ("air", 0.35),  # Air surrounding the body
-                1: ("bone", -11.1),
-                2: ("Teeth", -10),
-                3: ("Cervical spine", -9.7),
-                4: ("cartilage", -9.055),
-                5: ("watery tissue", -9.05),
-                6: ("extra (blood/muscle)", -9.04),
-                7: ("muscle", -9.03),
-                8: ("fat", -8.92),
-                9: ("lungs", -0.27),
-                10: ("Air", 0.35),
-                11: ("braces", 900),
-            }
-            return dicc_braces
     else:
         print("This tool hasn't been implemented yet.")

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -182,7 +182,7 @@ def return_dict_labels(tool, version, new_chi=None):
             dicc[324] = ("sc_gm", -9.03)
             # Additional to this we add trachea_cartilage and trachea_lumen
             dicc[170] = ("tr_cartilage", -9.055)
-            dicc[171] = ("tr_lumen", 0.27)  # Calculation done by S.R. following values from CRC Handbook
+            dicc[171] = ("tr_lumen", 0.196)  # Calculation done by S.R. following values from CRC Handbook and chi-opt
             return dicc
 
 
@@ -352,5 +352,171 @@ def return_dict_labels(tool, version, new_chi=None):
             }
             return dicc3
 
+    if tool  == "bracesTS":
+        if version == "v1":
+            # Unmerged labels - same values as v2
+            dicc_braces = {  # ICPR 143
+                0: ("air", 0.35),  # Air surrounding the body
+                1: ("kidney", -9.05),  # Adrenal, left
+                2: ("kidney", -9.05),  # Adrenal, right
+                3: ("Anterior nasal passage", -9.05),  # Anterior nasal passage (ET1)
+                4: ("Posterior nasal passage", -9.05),  # Posterior nasal passage (ET2)
+                5: ("Oral mucosa", -9.05),  # Oral mucosa, tongue
+                6: ("Oral mucosa", -9.05),  # Oral mucosa, lips and cheeks
+                7: ("trachea", -9.055),  # !!!!! only the tissue, air is separate
+                8: ("Bronchi", -9.05),  # !!!!! only the tissue air is separete
+                9: ("extra (blood/muscle)", -9.04),  # Blood vessels, head
+                10: ("extra (blood/muscle)", -9.04),  # Blood vessels, trunk
+                11: ("extra (blood/muscle)", -9.04),  # Blood vessels, arms
+                12: ("extra (blood/muscle)", -9.04),  # Blood vessels, legs
+                13: ("bone", -11.1),  # Humeri, upper half, cortical
+                14: ("bone", -11.1),  # Humeri, upper half, spongiosa
+                15: ("bone", -11.1),  # Humeri, upper half, medullary cavity
+                16: ("bone", -11.1),  # Humeri, lower half, cortical
+                17: ("bone", -11.1),  # Humeri, lower half, spongiosa
+                18: ("bone", -11.1),  # Humeri, lower half, medullary cavity
+                19: ("bone", -11.1),  # Ulnae and radii, cortical
+                20: ("bone", -11.1),  # Ulnae and radii, spongiosa
+                21: ("bone", -11.1),  # Ulnae and radii, medullary cavity
+                22: ("bone", -11.1),  # Wrists and hand bones, cortical
+                23: ("bone", -11.1),  # Wrists and hand bones, spongiosa
+                24: ("bone", -11.1),  # Clavicles, cortical
+                25: ("bone", -11.1),  # Clavicles, spongiosa
+                26: ("bone", -11.1),  # Cranium, cortical
+                27: ("bone", -11.1),  # Cranium, spongiosa
+                28: ("bone", -11.1),  # Femora, upper half, cortical
+                29: ("bone", -11.1),  # Femora, upper half, spongiosa
+                30: ("bone", -11.1),  # Femora, upper half, medullary cavity
+                31: ("bone", -11.1),  # Femora, lower half, cortical
+                32: ("bone", -11.1),  # Femora, lower half, spongiosa
+                33: ("bone", -11.1),  # Femora, lower half, medullary cavity
+                34: ("bone", -11.1),  # Tibiae, fibulae and patellae, cortical
+                35: ("bone", -11.1),  # Tibiae, fibulae and patellae, spongiosa
+                36: ("bone", -11.1),  # Tibiae, fibulae and patellae, medullary cavity
+                37: ("bone", -11.1),  # Ankles and foot bones, cortical
+                38: ("bone", -11.1),  # Ankles and foot bones, spongiosa
+                39: ("bone", -11.1),  # Mandible, cortical
+                40: ("bone", -11.1),  # Mandible, spongiosa
+                41: ("bone", -11.1),  # Pelvis, cortical
+                42: ("bone", -11.1),  # Pelvis, spongiosa
+                43: ("bone", -11.1),  # Ribs, cortical
+                44: ("bone", -11.1),  # Ribs, spongiosa
+                45: ("bone", -11.1),  # Scapulae, cortical
+                46: ("bone", -11.1),  # Scapulae, spongiosa
+                47: ("Cervical spine", -9.7),  # Cervical spine, cortical
+                48: ("Cervical spine", -9.7),  # Cervical spine, spongiosa
+                49: ("Thoracic spine", -9.7),  # Thoracic spine, cortical
+                50: ("Thoracic spine", -9.7),  # Thoracic spine, spongiosa
+                51: ("Lumbar spine", -9.7),  # Lumbar spine, cortical
+                52: ("Lumbar spine", -9.7),  # Lumbar spine, spongiosa
+                53: ("Sacrum", -9.7),  # Sacrum, cortical
+                54: ("Sacrum", -9.7),  # Sacrum, spongiosa
+                55: ("bone", -11.1),  # Sternum, cortical
+                56: ("bone", -11.1),  # Sternum, spongiosa
+                57: ("cartilage", -9.055),  # Cartilage, head
+                58: ("cartilage", -9.055),  # Cartilage, trunk
+                59: ("cartilage", -9.055),  # Cartilage, arms
+                60: ("cartilage", -9.055),  # Cartilage, legs
+                61: ("brain", -9.05),
+                62: ("fat", -8.92),  # Breast, left, adipose tissue
+                63: ("Breast", -9.05),  # Breast, left, glandular tissue
+                64: ("fat", -8.92),  # Breast, right, adipose tissue
+                65: ("Breast", -9.05),  # Breast, right, glandular tissue
+                66: ("Eye lens", -9.05),  # Eye lense, left
+                67: ("Eye bulb", -9.05),  # Eye bulb, left
+                68: ("Eye lens", -9.05),  # Eye lense, right
+                69: ("Eye bulb", -9.05),  # Eye bulb, right
+                70: ("Gall bladder", -9.05),  # Gall bladder wall
+                71: ("Gall bladder", -9.05),  # Gall bladder contents
+                72: ("Stomach", -9.05),  # Stomach wall
+                73: ("Stomach", -9.05),  # Stomach contents
+                74: ("Small intestine", -9.05),  # Small intestine wall
+                75: ("Small intestine", -9.05),  # Small intestine contents
+                76: ("Colon", -9.05),  # Ascending colon wall
+                77: ("Colon", -9.05),  # Ascending colon contents
+                78: ("Colon", -9.05),  # Transverse colon wall, right
+                79: ("Colon", -9.05),  # Transverse colon contents, right
+                80: ("Colon", -9.05),  # Transverse colon wall, left
+                81: ("Colon", -9.05),  # Transverse colon contents, left
+                82: ("Colon", -9.05),  # Descending colon wall
+                83: ("Colon", -9.05),  # Descending colon contents
+                84: ("Sigmoid colon", -9.05),  # Sigmoid colon wall
+                85: ("Sigmoid colon", -9.05),  # Sigmoid colon contents
+                86: ("Rectum", -9.05),  # Rectum wall
+                87: ("heart", -9.05),  # Heart wall
+                88: ("heart", -9.05),  # Heart contents (blood)
+                89: ("kidney", -9.05),  # Kidney, left, cortex
+                90: ("kidney", -9.05),  # Kidney, left, medulla
+                91: ("kidney", -9.05),  # Kidney, left, pelvis
+                92: ("kidney", -9.05),  # Kidney, right, cortex
+                93: ("kidney", -9.05),  # Kidney, right, medulla
+                94: ("kidney", -9.05),  # Kidney, right, pelvis
+                95: ("liver", -9.05),
+                96: ("lungs", -0.27),  # Lung, left, blood
+                97: ("lungs", -0.27),  # Lung, left, tissue
+                98: ("lungs", -0.27),  # Lung, right, blood
+                99: ("lungs", -0.27),  # Lung, right, tissue
+                100: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, extrathoracic airways
+                101: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, thoracic airways
+                102: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, head
+                103: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, trunk
+                104: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, arms
+                105: ("Lymphatic nodes", -9.05),  # Lymphatic nodes, legs
+                106: ("muscle", -9.03),  # Muscle, head
+                107: ("muscle", -9.03),  # Muscle, trunk
+                108: ("muscle", -9.03),  # Muscle, arms
+                109: ("muscle", -9.03),  # Muscle, legs
+                110: ("esophagus", -9.05),
+                111: ("Ovary", -9.05),  # Ovary, left
+                112: ("Ovary", -9.05),  # Ovary, right
+                113: ("pancreas", -9.05),
+                114: ("Pituitary gland", -9.05),  #
+                115: ("Prostate", -9.05),  #
+                116: ("Residual tissue", -9.05),  # Residual tissue, head
+                117: ("Residual tissue", -9.05),  # Residual tissue, trunk
+                118: ("Residual tissue", -9.05),  # Residual tissue, arms
+                119: ("Residual tissue", -9.05),  # Residual tissue, legs
+                120: ("Salivary glands", -9.05),  # Salivary glands, left
+                121: ("Salivary glands", -9.05),  # Salivary glands, right
+                122: ("Skin", -8.92),  # Skin, head
+                123: ("Skin", -8.92),  # Skin, trunk
+                124: ("Skin", -8.92),  # Skin, arms
+                125: ("Skin", -8.92),  # Skin, legs
+                126: ("spinal_cord", -9.055),
+                127: ("spleen", -9.05),
+                128: ("Teeth", -10),  # Teeth
+                129: ("Testis", -9.05),  # Testis, left
+                130: ("Testis", -9.05),  # Testis, right
+                131: ("Thymus", -9.05),  #
+                132: ("Thyroid", -9.05),  #
+                133: ("Tongue", -9.05),  # Tongue (inner part)
+                134: ("Tonsils", -9.05),  #
+                135: ("Ureter", -9.05),  # Ureter, left
+                136: ("Ureter", -9.05),  # Ureter, right
+                137: ("Urinary bladder", -9.05),  # Urinary bladder wall
+                138: ("water", -9.05),  # Urinary bladder contents
+                139: ("Uterus", -9.05),  #
+                140: ("Air", 0.35),  # Air inside body
+                141: ("braces", 300)  # Stainless stell 316L
+            }
+            return dicc_braces
+
+        if version == 'v2':
+            # Merged labels
+            dicc_braces = {  # for scan with merged labels
+                0: ("air", 0.35),  # Air surrounding the body
+                1: ("bone", -11.1),
+                2: ("Teeth", -10),
+                3: ("Cervical spine", -9.7),
+                4: ("cartilage", -9.055),
+                5: ("watery tissue", -9.05),
+                6: ("extra (blood/muscle)", -9.04),
+                7: ("muscle", -9.03),
+                8: ("fat", -8.92),
+                9: ("lungs", -0.27),
+                10: ("Air", 0.35),
+                11: ("braces", 300),
+            }
+            return dicc_braces
     else:
         print("This tool hasn't been implemented yet.")

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -515,7 +515,7 @@ def return_dict_labels(tool, version, new_chi=None):
                 8: ("fat", -8.92),
                 9: ("lungs", -0.27),
                 10: ("Air", 0.35),
-                11: ("braces", 300),
+                11: ("braces", 900),
             }
             return dicc_braces
     else:

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -286,7 +286,7 @@ def new_return_dict_labels(tool, version, new_chi=None):
                 82: ("extra", 100),  # Descending colon wall
                 83: ("extra", 100),  # Descending colon contents
                 84: ("extra", 100),  # Sigmoid colon wall
-                85: ("extra", -100),  # Sigmoid colon contents
+                85: ("extra", 100),  # Sigmoid colon contents
                 86: ("extra", 100),  # Rectum wall
                 87: ("heart", 1),  # Heart wall
                 88: ("heart", 1),  # Heart contents (blood)

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -193,8 +193,8 @@ def new_return_dict_labels(tool, version, new_chi=None):
             dicc[196] = ("sc_wm", 196)
             dicc[324] = ("sc_gm", 324)
             # Additional to this we add trachea_cartilage and trachea_lumen
-            dicc[170] = ("tr_cartilage", 7)
-            dicc[171] = ("tr_lumen", 13)  # Calculation done by S.R. following values from CRC Handbook and chi-opt
+            dicc[170] = ("tr_cartilage", 107)
+            dicc[171] = ("tr_lumen", 111)
             return dicc
 
 

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -4,6 +4,200 @@
 # I encourage to read her repo: https://github.com/evaalonsoortiz/Fourier-based-field-estimation
 
 # Important: When editing this lookup tables don't forget to edit the color map for itk and fsl
+
+def new_return_dict_labels(tool, version, new_chi=None):
+    '''
+    Function to generate a segmentation map that works with the repo's structure
+    We have pre-defined lable IDs and depending on the tool the user utilized for segmentation we can automate the process
+    Args:
+        tool: Specify the segmentation tool used: TotalSeg_CT,
+        version: Edited versions of the segmentation tool to include additional label IDs
+        new_chi (Optional): To replace the chi value of trachea and lungs (need revision)
+
+    Returns:
+        Dictionary with key, value: input_label_id: label_name, new_label_id
+    '''
+
+    if tool == "TotalSeg_CT":
+
+        # Using total segmentator we use follow their list for 117 labels
+        # and group them up based on their effect to the B0 map impact
+        # link: https://github.com/wasserth/TotalSegmentator/blob/master/totalsegmentator/map_to_binary.py
+
+        # Baseline dictionary for Total Segmentator CT
+        # id : name, susceptibility_value
+
+        dicc= {
+
+            0: ("air", 0),
+            1: ("spleen", 6),
+            2: ("kidney", 4), # kidney_right
+            3: ("kidney", 4), # kidney_left
+            4: ("organ", 102), # gallbladder
+            5: ("liver", 2), # liver
+            6: ("organ", 102), # stomach
+            7: ("organ", 102), # pancreas
+            8: ("gland", 19), # adrenal gland left
+            9: ("gland", 19), # adrenal_gland_left
+            # Updated as of August 2025 (compare_fm + chi_opt)
+            10: ("lungs", 12), # lung_upper_lobe_left
+            11: ("lungs", 12), # lung_lower_lobe_left
+            12: ("lungs", 12), # lung_upper_lobe_right
+            13: ("lungs", 12), # lung_middle_lobe_right
+            14: ("lungs", 12), # lung_lower_lobe_right
+            15: ("esophagus", 18),
+            16: ("trachea", 13),
+            #
+            17: ("gland", 19), # thyroid_gland
+            18: ("organ", 102), # small_bowel
+            19: ("organ", 102), # duodenum
+            20: ("organ", 102), # colon
+            21: ("organ", 102), # urinary_bladder
+            22: ("organ", 102), # prostate
+            23: ("kidney", 4), # kidney_cyst_left
+            24: ("kidney", 4), # kidney_cyst_right
+            25: ("v_bone", 11), # sacrum
+            26: ("v_bone", 11), #vertebrae_S1
+            27: ("v_bone", 11), # vertebrae_L5
+            28: ("v_bone", 11), # vertebrae_L4
+            29: ("v_bone", 11), # vertebrae_L3
+            30: ("v_bone", 11), # vertebrae_L2
+            31: ("v_bone", 11), # vertebrae_L1
+            32: ("v_bone", 11), # vertebrae_T12
+            33: ("v_bone", 11), # vertebrae_T11
+            34: ("v_bone", 11), # vertebrae_T10
+            35: ("v_bone", 11), # vertebrae_T9
+            36: ("v_bone", 11), # vertebrae_T8
+            37: ("v_bone", 11), # vertebrae_T7
+            38: ("v_bone", 11), # vertebrae_T6
+            39: ("v_bone", 11), #vertebrae_T5
+            40: ("v_bone", 11), # vertebrae_T4
+            41: ("v_bone", 11), #vertebrae_T3
+            42: ("v_bone", 11), # vertebrae_T2
+            43: ("v_bone", 11), # vertebrae_T1
+            44: ("v_bone", 11), # vertebrae_C7
+            45: ("v_bone", 11), # vertebrae_C6
+            46: ("v_bone", 11), # vertebrae_C5
+            47: ("v_bone", 11), # vertebrae_C4
+            48: ("v_bone", 11), # vertebrae_C3
+            49: ("v_bone", 11), # vertebrae_C2
+            50: ("v_bone", 11), # vertebrae_C1
+            51: ("heart", 1), # heart
+            52: ("extra", 100), # aorta
+            53: ("extra", 100), # pulmonary_vein
+            54: ("extra", 100), # brachiocephalic_trunk
+            55: ("extra", 100), # subclavian_artery_right
+            56: ("extra", 100), # subclavian_artery_left
+            57: ("extra", 100), # common_carotid_artery_right
+            58: ("extra", 100), # common_carotid_artery_left
+            59: ("extra", 100), # brachiocephalic_vein_left
+            60: ("extra", 100), # brachiocephalic_vein_right
+            61: ("extra", 100), # atrial_appendage_left
+            62: ("extra", 100), # superior_vena_cava
+            63: ("extra", 100), # inferior_vena_cava
+            64: ("extra", 100), # portal_vein_and_splenic_vein
+            65: ("extra", 100), # iliac_artery_left
+            66: ("extra", 100), # iliac_artery_right
+            67: ("extra", 100), # iliac_vena_left
+            68: ("extra", 100), # iliac_vena_right
+            69: ("bone", 10), # humerus_left
+            70: ("bone", 10), # humerus_right
+            71: ("bone", 10), # scapula_left
+            72: ("bone", 10), # scapula_right
+            73: ("bone", 10), # clavicula_left
+            74: ("bone", 10), # clavicula_right
+            75: ("bone", 10), # femur_left
+            76: ("bone", 10), # femur_right
+            77: ("bone", 10), # hip_left
+            78: ("bone", 10), # hip_right
+            79: ("spinal_cord",14), # Spinal Canal (from Total Seg)
+            80: ("muscle", 9), # gluteus_maximus_left
+            81: ("muscle", 9), # gluteus_maximus_right
+            82: ("muscle", 9), # gluteus_medius_left
+            83: ("muscle", 9), # gluteus_medius_right
+            84: ("muscle", 9), # gluteus_minimus_left
+            85: ("muscle", 9), # gluteus_minimus_right
+            86: ("muscle", 9), # autochthon_left
+            87: ("muscle", 9), # autochthon_right
+            88: ("muscle", 9), # iliopsoas_left
+            89: ("muscle", 9), # iliopsoas_right
+            90: ("brain", 5), # brain
+            91: ("bone", 10), # skull
+            92: ("bone", 10), # rib_left_1
+            93: ("bone", 10), # rib_left_2
+            94: ("bone", 10), # rib_left_3
+            95: ("bone", 10), # rib_left_4
+            96: ("bone", 10), # rib_left_5
+            97: ("bone", 10), # rib_left_6
+            98: ("bone", 10), # rib_left_7
+            99: ("bone", 10), # rib_left_8
+            100: ("bone", 10), # rib_left_9
+            101: ("bone", 10), # rib_left_10
+            102: ("bone", 10), # rib_left_11
+            103: ("bone", 10), # rib_left_12
+            104: ("bone", 10), # rib_right_1
+            105: ("bone", 10), # rib_right_2
+            106: ("bone", 10), # rib_right_3
+            107: ("bone", 10), # rib_right_4
+            108: ("bone", 10), # rib_right_5
+            109: ("bone", 10), # rib_right_6
+            110: ("bone", 10), # rib_right_7
+            111: ("bone", 10), # rib_right_8
+            112: ("bone", 10), # rib_right_9
+            113: ("bone", 10), # rib_right_10
+            114: ("bone", 10), # rib_right_11
+            115: ("bone", 10), # rib_right_12
+            116: ("bone", 10), # sternum
+            117: ("cartilage", 7) # costal_cartilages
+        }
+
+        if version == "v2":
+            return dicc
+
+        if version == "mod0":
+            # This means it has labels + fat = Whole body
+            dicc[264]=("fat", 264)
+            return dicc
+
+        if version == "mod1":
+            # This means its Whole body + Spinal Cord CSF to differentiate Spinal Canal
+            # from spinal cord
+            dicc[264]=("fat", 264)
+            dicc[256]=("spinal_cord", 14)
+            dicc[289]=("sc_csf", 289)
+            return dicc
+
+        if version=="mod2":
+            # This means it has CSF + Spinal Cord + WM/GM segmentation instead of Spina Canal
+            dicc[264]=("fat", 264)
+            #dicc[256] = ("spinal_cord", -9.055)
+            # If labels are done correctly, spinalcord (as well as spinal canal #79)
+            # should not be really appearing and not needed to state values for them
+            # hence my comment on previous line.
+            dicc[289] = ("sc_csf", 289)
+
+            dicc[196] = ("sc_wm", 196)
+            dicc[324] = ("sc_gm", 324)
+
+            return dicc
+
+        if version == "mod3":
+            # This means it has CSF + Spinal Cord + WM/GM segmentation instead of Spina Canal
+            dicc[264] = ("fat", 264)
+            # dicc[256] = ("spinal_cord", -9.055)
+            # If labels are done correctly, spinalcord (as well as spinal canal #79)
+            # should not be really appearing and not needed to state values for them
+            # hence my comment on previous line.
+            dicc[289] = ("sc_csf", 289)
+
+            dicc[196] = ("sc_wm", 196)
+            dicc[324] = ("sc_gm", 324)
+            # Additional to this we add trachea_cartilage and trachea_lumen
+            dicc[170] = ("tr_cartilage", 7)
+            dicc[171] = ("tr_lumen", 13)  # Calculation done by S.R. following values from CRC Handbook and chi-opt
+            return dicc
+
+
 def return_dict_labels(tool, version, new_chi=None):
 
     if tool == "TotalSeg_CT":

--- a/tissue2mrprop/functions/utils/select_tool.py
+++ b/tissue2mrprop/functions/utils/select_tool.py
@@ -497,7 +497,7 @@ def return_dict_labels(tool, version, new_chi=None):
                 138: ("water", -9.05),  # Urinary bladder contents
                 139: ("Uterus", -9.05),  #
                 140: ("Air", 0.35),  # Air inside body
-                141: ("braces", 300)  # Stainless stell 316L
+                141: ("braces", 900)  # Stainless stell 316L
             }
             return dicc_braces
 

--- a/tissue2mrprop/functions/utils/utils.py
+++ b/tissue2mrprop/functions/utils/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import nibabel as nib
 import argparse
-import scipy
 
 def is_nifti(filepath):
     """

--- a/tissue2mrprop/functions/volume.py
+++ b/tissue2mrprop/functions/volume.py
@@ -159,6 +159,8 @@ class volume:
             lbl.set_name(name) # This enables us to call all tissue properties as attributes per label
             self.segmentation_labels[lab_id] = lbl
 
+        # At the end of the loop segmentation_labels has a Label object indexed by the canonical IDs!
+
         # Additionally, getting relax and static values from any segmentation label
         self.relax_values = next(
             iter(self.segmentation_labels.values())).relax_values if self.segmentation_labels else {}

--- a/tissue2mrprop/functions/volume.py
+++ b/tissue2mrprop/functions/volume.py
@@ -4,8 +4,9 @@ from tissue2mrprop.functions.label import SegmentationLabel
 import nibabel as nib
 from tissue2mrprop.functions.utils.get_dic_values import to_csv_sus
 import os
-from tissue2mrprop.functions.utils.select_tool import return_dict_labels, new_return_dict_labels
-#from skimage.measure import label, regionprops
+from tissue2mrprop.functions.utils.select_tool import new_return_dict_labels
+from tissue2mrprop.conventions import CANONICAL_ID_TO_NAME
+
 
 # Parent class for the creation of a non-finite biomechanical model of the body
 class volume:
@@ -17,7 +18,8 @@ class volume:
         # This way we can attribute the information from nifti files to the class
 
         self.nifti = volume # This points to a Nifti file
-        self.volume = self.nifti.get_fdata()
+        # Given the input is ALWAYS a segmentation, we should open them as integers
+        self.volume = self.nifti.get_fdata().astype(np.int32)
         self.dimensions = np.array(self.volume.shape) # It is initially a tuple, but it needs to be an array
         self.uniq_labels = np.unique(self.volume)
         self.segmentation_labels = {}
@@ -38,6 +40,7 @@ class volume:
         # This is the Convention Dictionary for labels_id - names - sus_values
         self.relax_values = {}
         self.static_vals = {}
+        self.static_vals_short = {}
         # This is a dictionary to get the relaxation values used in label.py
 
         # Now to get the dictionary of standard deviations
@@ -67,477 +70,297 @@ class volume:
         # For the fieldmap comparison project:
         self.new_chi = None
 
-    def group_seg_labels(self, tool, version, type, ref):
-        #self.look_up = return_dict_labels(tool,version)
-        # For the fieldmap comparison project
-        if tool == "compare_fm" and version == "dyn":
-            # If the version is dynamic
-            # The new value will replace None
-            # We can check just in case
-            self.look_up = new_return_dict_labels(tool,version, new_chi = self.new_chi)
-        else:
-            self.look_up = new_return_dict_labels(tool,version)
+    def group_seg_labels(self, tool, version, in_fn):
 
-        # Function to get the relaxation values from label
-        for i in self.look_up.keys():
-            self.segmentation_labels[i] = SegmentationLabel(i)
+        self.look_up = new_return_dict_labels(tool,version)
 
         for key, value in self.look_up.items():
             # Key is the number of ID and value is (name, new_id)
             name = value[0]
             new_id = value[1]
-            self.set_label_name(key, name, type)
 
+        # Now, check pixel integrity
+        try:
+            self.check_pixels(in_fn)
+        except ValueError:
+            return False
+        return True
 
-            if ref != 0:
-                new_sus = sus - ref
-                self.set_label_susceptibility(key, new_sus)
-
-
-
-            if type == "sus":
-                print(name, " Chi:", self.segmentation_labels[key].PD_val)
-            if type == "pd":
-                print(name, " PD:", self.segmentation_labels[key].PD_val)
-            if type == "t2s":
-                print(name, " T2s:", self.segmentation_labels[key].T2star_val)
-            if type == "t1":
-                print(name, " T1:", self.segmentation_labels[key].T1_val)
-            if type == "t2":
-                print(name, " T2:", self.segmentation_labels[key].T2_val)
-            if type == "perm3T":
-                print(name, " Permittivity@3T:", self.segmentation_labels[key].perm3T)
-            if type == "cond3T":
-                print(name, " Conductivity @3T:", self.segmentation_labels[key].cond3T)
-            if type == "perm7T":
-                print(name, " Permittivity @7T:", self.segmentation_labels[key].perm7T)
-            if type == "cond7T":
-                print(name, " Permittivity @7T:", self.segmentation_labels[key].cond7T)
-
-        # Getting the relax values dictionary from any label
-        self.relax_values = self.segmentation_labels[0].relax_values
-        self.static_vals = self.segmentation_labels[0].static_values_short
-
-    def check_labels(self):
-        for i in self.uniq_labels:
-            if self.segmentation_labels[i].name == None:
-                print("Label: ",self.segmentation_labels[i]["name"]," doesn't have name assigned")
-
-    def set_label_name(self, label_id, name, type):
-        '''
-        This is the most important set function, as this function enables the calling the tissue properties as attributes
-        if and only if the label is found in the ids
-        '''
-        ids = self.look_up.keys()
-        if label_id in ids:
-            if type == "perm3T" or type == "cond3T" or type == "perm7T" or type == "cond7T":
-                self.segmentation_labels[label_id].set_static_name(name)
-
-            self.segmentation_labels[label_id].set_name(name)
-        else:
-            print(f"Label ID {label_id} not found, check version selected")
-            exit()
-
-    def set_label_susceptibility(self, label_id, susceptibility):
-        ids = self.look_up.keys()
-        if label_id in ids:
-            self.segmentation_labels[label_id].set_susceptibility(susceptibility)
-        else:
-            print(f"Label ID {label_id} not found.")
-            exit()
-    def set_T1(self, label_id, t1):
-        ids = self.look_up.keys()
-        if label_id in ids:
-            self.segmentation_labels[label_id].set_t2star_val(t1)
-        else:
-            print(f"Label ID {label_id} not found.")
-            exit()
-    def set_label_pd(self,label_id,pd):
-        ids = self.look_up.keys()
-        if label_id in ids:
-            self.segmentation_labels[label_id].set_pd_val(pd)
-        else: print(f"Label ID {label_id} not found.")
-
-    def set_T2star(self, label_id, t2star):
-        ids = self.look_up.keys()
-        if label_id in ids:
-            self.segmentation_labels[label_id].set_t2star_val(t2star)
-        else:
-            print(f"Label ID {label_id} not found.")
-
-    def manual_label(self,id,name,sus):
-        if id in self.uniq_labels:
-            label = self.segmentation_labels[id]
-            label.name = name
-            label.sus = sus
-
-    def show_labels(self):
-        for i in self.segmentation_labels:
-            label = self.segmentation_labels[i]
-            print(label) # Calling __str__ from label
-
-    def create_type_vol(self, type, output_name="default"):
-        # This function is for the CLI app
-        # Depending on the type we automatically call the specific function
-        # Piece-wise mode: on :P
-        if type == 'sus':
-            self.create_sus_dist()
-            self.save_sus_dist_nii(output_name)
-        if type == 't2s':
-            self.create_t2_star_vol()
-            self.save_t2star_dist(output_name)
-        if type == 'pd':
-            self.create_pd_vol()
-            self.save_pd_dist(output_name)
-        if type == 't1':
-            self.create_t1_vol()
-            self.save_t1_dist(output_name)
-        if type == 't2':
-            print("T2 volume comming soon!")
-
-        if type == 'perm3T' or type == 'cond3T' or type == 'perm7T' or type == 'cond7T':
-            self.create_static_vol(type)
-            self.save_static_vol(type, output_name)
-
-
-
-    def check_pixels(self,input_name):
+    def check_pixels(self, input_name):
         # Important to before going to conversion
         # If there is a pixel that is outside of range conversion won't work
         # because it won't be treated as a label but as a float
         flag = 0  # Flag to save in case there were changes
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
+        volume_labels = self.uniq_labels
+        valid_labels = np.array(list(self.look_up.keys()))
+        # Now with lists instead of 3D arrays we can find any invalid labels
+        invalid_labels = np.setdiff1d(volume_labels, valid_labels)
 
-                    pixel = self.volume[i, j, k]
+        if invalid_labels.size == 0:
+            print("✅ All segmentation labels match the lookup table.")
+            return True
 
-                    if pixel not in self.look_up.keys():
+        print("⚠️ Found labels not defined in selected tool:")
+        print(invalid_labels)
 
-                        flag = 1
-                        print(f"Pixel with wrong value: {pixel} located at {i,j,k}")
-                        print("(indexed from [0,0,0])")
-                        rem = str(input("Do you want to delete the pixel? [Y] [n]: "))
-                        print("[Y] continues checking pixels, [n] lets you edit it")
+        # Create mask of invalid voxels
+        invalid_mask = np.isin(self.volume, invalid_labels)
 
-                        if rem == "n":
-                            print("Maybe you want to change the value?")
-                            rem2 = int(input("Choose the value: "))
+        # Create output volume (only invalid labels kept)
+        invalid_volume = np.zeros_like(self.volume)
+        invalid_volume[invalid_mask] = self.volume[invalid_mask]
 
-                            if rem2 in self.segmentation_labels:
-                                print("Changed value to: ", rem2)
-                                self.volume[i, j, k] = rem2
+        # Save NIfTI
+        tmp_img = nib.Nifti1Image(invalid_volume,header=self.nifti.header, affine=self.nifti.affine)
 
-                            else:
-                                print("Number not in look up table")
-                                return 1
-
-                        if rem == "Y" or rem == "y":
-                            self.volume[i, j, k] = 0
-
+        if input_name.endswith(".nii.gz"):
+            base_name = input_name[:-7]
+            out_name = base_name + "_invalid_labels.nii.gz"
+        elif input_name.endswith(".nii"):
+            base_name = input_name[:-4]
+            out_name = base_name + "_invalid_labels.nii.gz"
         else:
+            out_name = "invalid_labels.nii.gz"
+            print("Input filename not nifti or compressed nifit")
 
-            if flag == 1:
+        out_path = os.path.join("output", out_name)
+        nib.save(tmp_img, out_path)
 
-                print("Saving corrected volume for later usage!")
-                tmp_img = nib.Nifti1Image(self.volume, affine = self.nifti.affine)
-                if input_name.endswith(".nii.gz"):  # Maybe code for .nii later (not urgent)
-                    base_name = input_name[:-7]  # Remove the `.nii.gz`
-                    extension = ".nii.gz"
-                out_name = base_name + "corrected_pixels.nii.gz"
-                path = os.path.join('output', out_name)
-                nib.save(tmp_img,path)
-                del tmp_img
-                del path
-                return 0
+        print(f"🚨 Invalid label map saved to: {out_path}")
+        print("Please correct segmentation or select the appropriate tool.")
 
-            else:
-                print("Input has correct pixel integrity!")
-                return 0
+        raise ValueError("Segmentation contains labels incompatible with selected tool.")
 
     def create_new_grouped_labels(self):
-        self.grouped_labels = np.zeros(self.dimensions)
+        # Redefine volume to int so that we can use indexing
+        # If we don't do this, we can't index with floats
+        print("Checking type of volume:", type(self.volume))
+        max_label = int(np.max(self.volume))
+        lut = np.zeros(max_label+1, dtype=int)
+        for key, (name, new_id) in self.look_up.items():
+            if key <= max_label:
+                print(f"Remapping label {name} to {new_id}")
+                lut[key] = new_id # The second value of the tuple is the new id
 
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
+        self.grouped_labels = lut[self.volume]
+        return self.grouped_labels
 
-                    pixel = self.volume[i,j,k]
-                    label = self.segmentation_labels[pixel]
-                    new_label_id = self.segmentation_labels
+# Initializing tissue2MR using Canonical list of label id-name
 
-    def create_sus_dist(self):
-        # Code for create a susceptibility distribution volume
-        # Using the label class
-        self.sus_dist = np.zeros(self.dimensions)
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
+    def init_segmentation_labels_from_canonical(self):
+        self.segmentation_labels = {}
+        for lab_id in self.uniq_labels:
+            lab_id = int(lab_id)
+            lbl = SegmentationLabel(lab_id)
 
-                    pixel = self.volume[i,j,k]
+            if lab_id not in CANONICAL_ID_TO_NAME:
+                raise ValueError(f"Label ID {lab_id} not found, check tool and version selected")
+            name = CANONICAL_ID_TO_NAME[lab_id]
+            lbl.set_name(name) # This enables us to call all tissue properties as attributes per label
+            self.segmentation_labels[lab_id] = lbl
 
-                    label = self.segmentation_labels[pixel]
-                    suscep = label.susceptibility
+        # Additionally, getting relax and static values from any segmentation label
+        self.relax_values = next(
+            iter(self.segmentation_labels.values())).relax_values if self.segmentation_labels else {}
+        self.static_vals_short = next(
+            iter(self.segmentation_labels.values())).static_values_short if self.segmentation_labels else {}
+        self.static_vals = next(
+            iter(self.segmentation_labels.values())).static_values if self.segmentation_labels else {}
 
-                    if suscep == None:
-                        # THis means the label is not defined
-                        # The only not defined labels are organs
-                        # We can consider the suscp of water
-                        self.sus_dist[i,j,k] = -9.05
-                    else:
-                        self.sus_dist[i,j,k] = suscep
+# Core function for creating new volumes without having to use 3 for loops
+    def _lut_from_label_attr(self, attr_name:str, default_value:float, dtype=np.float32):
+        """
+        Builds a LUT mapping label_id -> attribute value then returns the mapped volume
+        attr_name examples: susceptibility, T1_val, T2star_val, PD_val, T2_val
+        """
+        max_label = int(self.volume.max())
+        lut = np.full(max_label+1, default_value, dtype=dtype)
 
-        return self.sus_dist
+        # Now iterate only over unique labels present (faster)
+        for lab_id in self.uniq_labels:
+            lab_id = int(lab_id)
+            lbl = self.segmentation_labels.get(lab_id, None)
+            if lbl is None:
+                continue
+            val = getattr(lbl, attr_name, None)
+            # None in case we get missing attributes or if typo on attr_name
+            if val is None:
+                continue
+            lut[lab_id] = float(val)
 
-    def save_sus_dist_nii(self, fn):
-        # Method to save the susceptibility distribution created to nifti
-        if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
-            g_str = "gauss"
+        return lut[self.volume]
+
+# Create new volume house function
+    def create_type_vol(self, mrprop, output_name="default"):
+        # This function is for the CLI app
+        # Depending on the type we automatically call the specific function
+        # Piece-wise mode: on :P
+        if mrprop == 'sus':
+            self.sus_dist = self._lut_from_label_attr(
+                attr_name="susceptibility",
+                default_value=-9.05,  # In case None is found on a label's chi value
+                dtype=np.float32
+            )
+            self.save_sus_dist(output_name)
+        elif mrprop == 't2s':
+            self.t2star_vol = self._lut_from_label_attr(
+                attr_name="T2star_val",
+                default_value=0,  # In case None is found on a label's T2star value
+                dtype=np.float32
+            )
+            self.save_t2star_dist(output_name)
+        elif mrprop == 'pd':
+            self.pd_dist= self._lut_from_label_attr(
+                attr_name="PD_val",
+                default_value=0,  # In case None is found on a label's PD value
+                dtype=np.float32
+            )
+            self.save_pd_dist(output_name)
+        elif mrprop == 't1':
+            self.t1_vol = self._lut_from_label_attr(
+                attr_name="T1_val",
+                default_value=0,  # In case None is found on a label's T1 value
+                dtype=np.float32
+            )
+            self.save_t1_dist(output_name)
+        elif mrprop == 't2':
+            self.t2_vol = self._lut_from_label_attr(
+                attr_name="T2_val",
+                default_value=0,  # In case None is found on a label's T2 value
+                dtype=np.float32
+            )
+            self.save_t2_dist(output_name)
+
+        elif mrprop in ('perm3T', 'cond3T', 'perm7T', 'cond7T'):
+            self.create_static_vol(mrprop)
+            self.save_static_vol(mrprop, output_name)
         else:
-            temp_img = nib.Nifti1Image(self.sus_dist, affine=self.nifti.affine)
+            raise ValueError(f"Unknown property: {mrprop}")
+
+    def save_sus_dist(self, fn):
+        if self.gauss_flag:
+            data = self.gaussian_phantom
+        else:
+            data = self.sus_dist
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
 
         if fn == "default":
             fn = 'sus_dist.nii.gz'
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            # Conditioning if gauss flag is active, if not. We use the susceptibility np array
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-
-        del temp_img
-        del path
-
-    def create_static_vol(self, type):
-
-        self.static_vol = np.zeros(self.dimensions)
-        # Recall the type will tell us what index to take from the perm&cond dictionary
-
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-
-                    pixel = self.volume[i,j,k]
-
-                    label = self.segmentation_labels[pixel]
-
-                    if type == "perm3T":
-                        stat = label.perm3T
-                        self.static_vol[i, j, k] = stat
-
-                    if type == "cond3T":
-                        stat = label.cond3T
-                        self.static_vol[i, j, k] = stat
-
-                    if type == "perm7T":
-                        stat = label.perm7T
-                        self.static_vol[i, j, k] = stat
-
-                    if type == "cond7T":
-                        stat = label.cond7T
-                        self.static_vol[i, j, k] = stat
-
-                    #else:
-                        #print(f"Label {label} doesn't have a Perm or Cond value associated, check dictionary")
-                        #exit()
-
-        return self.static_vol
-
-    def save_static_vol(self, type, fn="default"):
-        # Method to save the Perm or Cond vol created to nifti
         if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
-            g_str = "gauss"
-        else:
-            temp_img = nib.Nifti1Image(self.static_vol, affine=self.nifti.affine)
+            fn = "gauss_" + fn
+        path = os.path.join('output', fn)
+        nib.save(tmp_img,path)
 
-        if fn == "default":
-            fn = type+'.nii.gz'
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            # Conditioning if gauss flag is active, if not. We use the static_vol np array
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img, path)
-        else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img, path)
-
-        del temp_img
-        del path
-
-    def create_t1_vol(self):
-        self.t1_vol = np.zeros(self.dimensions)
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-                    pixel = self.volume[i,j,k]
-                    label = self.segmentation_labels[pixel]
-                    val_t1 = label.T1_val
-                    if val_t1 == None:
-                        print("Label: ",label.name," does not have T1 value")
-                        self.t1_vol[i,j,k] = 0
-                    else:
-                        self.t1_vol[i, j, k] = val_t1
-        return self.t1_vol
+        del tmp_img
+        return path
 
     def save_t1_dist(self, fn = "default"):
-        # Method to save T1 volume created to nifti
         if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
+            data = self.gaussian_phantom
         else:
-            temp_img = nib.Nifti1Image(self.t1_vol, affine=self.nifti.affine)
+            data = self.t1_vol
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
 
         if fn == "default":
             fn = 't1_dist.nii.gz'
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            nib.save(temp_img,path)
-        else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            nib.save(temp_img,path)
-        del temp_img
-        del path
-
-    def create_pd_vol(self):
-        # This method will use the lookup table of PD values to create a new volume
-        # This new volume will use the labels to quickly create a volume with ProtonDensity values
-        self.pd_dist = np.zeros(self.dimensions)
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-
-                    pixel = self.volume[i,j,k]
-                    label = self.segmentation_labels[pixel]
-                    pd = label.PD_val
-                    if pd == None:
-                        # THis means the label does not have PD defined
-                        self.pd_dist[i,j,k] = 0
-                    else:
-                        # If the label has PD value it will put this value on the volume
-                        self.pd_dist[i,j,k] = pd
-
-        return self.pd_dist
-    def save_pd_dist(self, fn = 'default'):
-        # Method to save the proton density distribution created to nifti
         if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
+            fn = "gauss_" + fn
+        path = os.path.join('output', fn)
+        nib.save(tmp_img,path)
+
+        del tmp_img
+        return path
+
+    def save_pd_dist(self, fn = 'default'):
+        if self.gauss_flag:
+            data = self.gaussian_phantom
         else:
-            temp_img = nib.Nifti1Image(self.pd_dist, affine=self.nifti.affine)
+            data = self.pd_dist
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
 
         if fn == "default":
             fn = 'pd_dist.nii.gz'
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        del temp_img
-        del path
-
-    def create_t2_star_vol(self):
-        # This method will use the lookup table of T2 star values to create a new volume
-        # This new volume will use the labels to quickly create a volume with relaxation time
-        self.t2star_vol = np.zeros(self.dimensions)
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-
-                    pixel = self.volume[i,j,k]
-                    label = self.segmentation_labels[pixel]
-                    t2star = label.T2star_val
-                    if t2star == None:
-                        # THis means the label does not have T2 star value defined
-                        self.t2star_vol[i,j,k] = 0.001
-                    else:
-                        # If the label has value it will put this value on the volume
-                        self.t2star_vol[i,j,k] = t2star
-
-        return self.t2star_vol
-    def save_t2star_dist(self, fn = "default"):
-        # Method to save the volume with T2 star values  created to nifti
         if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
+            fn = "gauss_" + fn
+        path = os.path.join('output', fn)
+        nib.save(tmp_img,path)
+
+        del tmp_img
+        return path
+
+    def save_t2star_dist(self, fn = "default"):
+        if self.gauss_flag:
+            data = self.gaussian_phantom
         else:
-            temp_img = nib.Nifti1Image(self.t2star_vol, affine=self.nifti.affine)
+            data = self.t2star_vol
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
 
         if fn == "default":
             fn = 't2_star.nii.gz'
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        del temp_img
-        del path
+        if self.gauss_flag:
+            fn = "gauss_" + fn
+        path = os.path.join('output', fn)
+        nib.save(tmp_img,path)
 
-    def create_t2_vol(self):
-        # This method will use the lookup table of T2 star values to create a new volume
-        # This new volume will use the labels to quickly create a volume with relaxation time
-        self.t2_vol = np.zeros(self.dimensions)
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-
-                    pixel = self.volume[i, j, k]
-                    label = self.segmentation_labels[pixel]
-                    t2val = label.T2_val
-                    if t2val == None:
-                        # THis means the label does not have T2 defined
-                        self.t2_vol[i, j, k] = 0.001
-                    else:
-                        # If the label has value it will put this value on the volume
-                        self.t2_vol[i, j, k] = t2val
-
-        return self.t2_vol
+        del tmp_img
+        return path
 
     def save_t2_dist(self, fn = "default"):
-        # Method to save the volume with T2 star values  created to nifti
         if self.gauss_flag:
-            temp_img = nib.Nifti1Image(self.gaussian_phantom, affine=self.nifti.affine)
+            data = self.gaussian_phantom
         else:
-            temp_img = nib.Nifti1Image(self.t2_vol, affine=self.nifti.affine)
+            data = self.t2_vol
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
 
         if fn == "default":
-            fn = 't2_map.nii.gz'
-            if self.gauss_flag:
+            fn = 't2_dist.nii.gz'
+        if self.gauss_flag:
                 fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
+        path = os.path.join('output', fn)
+        nib.save(tmp_img,path)
+
+        del tmp_img
+        return path
+
+    def create_static_vol(self, mrprop):
+        attr_map = {
+            "perm3T": "perm3T",
+            "cond3T": "cond3T",
+            "perm7T": "perm7T",
+            "cond7T": "cond7T",
+        }
+
+        if mrprop not in attr_map:
+            raise ValueError(f"Unknown static type: {mrprop}")
+
+        attr_name = attr_map[mrprop]
+
+        # Undefined values default to 0
+        self.static_vol = self._lut_from_label_attr(
+            attr_name=attr_name,
+            default_value=0.0,
+            dtype=np.float32
+        )
+        return self.static_vol
+
+    def save_static_vol(self, mrprop, fn="default"):
+        if self.gauss_flag:
+            data = self.gaussian_phantom
         else:
-            if self.gauss_flag:
-                fn = "gauss_" + fn
-            path = os.path.join('output', fn)
-            # Save the new NIfTI image to a file
-            nib.save(temp_img,path)
-        del temp_img
-        del path
+            data = self.static_vol
+        tmp_img = nib.Nifti1Image(data, affine=self.nifti.affine)
+
+        if fn == "default":
+            fn = f"{mrprop}.nii.gz"
+        if self.gauss_flag:
+            fn = "gauss_" + fn
+        path = os.path.join('output', fn)
+        nib.save(tmp_img, path)
+
+        del tmp_img
+        return path
+
+# CSV related functions (on development)
     def save_sus_csv(self):
         data = []
         for i in self.segmentation_labels.keys():
@@ -558,37 +381,32 @@ class volume:
         # It might be usefull to get this inputs from different researchers and testing
         pass
 
+# Gaussian related functions
     def calc_regions(self):
         # For  creating a gaussian distribution we need to group and count every label
         # Must be run after defining a tool in group_seg_labels
-        self.gaussian_phantom = np.zeros(self.dimensions)
+        self.gaussian_phantom = np.zeros(self.dimensions, dtype=np.float32)
+
         unique_labels, counts = np.unique(self.volume, return_counts=True)
         self.unique_counts = dict(zip(unique_labels,counts))
 
         std_regions_of_interest = ["sc_wm", "sc_gm"]
 
-        if self.look_up is {}:
+        if not self.look_up:
             print("Please define a tool for a lookup table")
+            return
 
-        else:
-            for l, count in self.unique_counts.items():
-                #label_id = l
-                label_name = self.look_up[l][0]
-                #label_suscep = self.look_up[l][1]
-                # Filter only for SC wm and gm
-                if label_name == std_regions_of_interest[0] or std_regions_of_interest[1]:
-                    if label_name in self.label_counts.keys():
-                        self.label_counts[label_name] += count
-                    else:
-                        self.label_counts[label_name] = count
+        self.label_counts = {}
 
-        # Now depending on the tool used we grouped them up
-        # And for visualizing, sorting might be good
-        sorted_label_counts = sorted(self.label_counts.items(), key=lambda item: item[1], reverse=True)
+        for lab_id, count in self.unique_counts.items():
+            lab_id = int(lab_id)
+            if lab_id not in self.look_up:
+                continue
+            label_name = self.look_up[lab_id][0]
+            if label_name in std_regions_of_interest:
+                self.label_counts[label_name] = self.label_counts.get(label_name, 0) + int(count)
 
-        # Now should only show SC gm and wm
-        for name, count in sorted_label_counts:
-            # Display the pixel count per label
+        for name, count in sorted(self.label_counts.items(), key=lambda x: x[1], reverse=True):
             print(f"Label name: {name}: {count} pixels")
 
     def create_gauss_sc_dist(self, prop):
@@ -600,7 +418,12 @@ class volume:
             "t2": {"sc_wm": 8.725, "sc_gm": 14.935}, # Using sub-MKP611 from https://openneuro.org/datasets/ds004611/versions/1.0.2
             "t1": {"sc_wm": 106.15, "sc_gm": 114.895}, # Using sub-MKP611 from https://openneuro.org/datasets/ds004611/versions/1.0.2
             "pd": {"sc_wm": 5.54, "sc_gm": 6.95}, # Same as M0 for now
-            "M0": {"sc_wm": 13.41, "sc_gm": 16.83} # => Avg taken from regions 1 through 7 of QSM RC2 paper (Deep gray matter) for GM and WM
+            "M0": {"sc_wm": 13.41, "sc_gm": 16.83}, # => Avg taken from regions 1 through 7 of QSM RC2 paper (Deep gray matter) for GM and WM
+            # STD values for the following properties still need to be added
+            "perm3T": {"sc_wm": 0.01, "sc_gm": 0.01},
+            "cond3T": {"sc_wm": 0.01, "sc_gm": 0.01},
+            "perm7T": {"sc_wm": 0.01, "sc_gm": 0.01},
+            "cond7T": {"sc_wm": 0.01, "sc_gm": 0.01}
         }
         # WM values come from corpus callosum
         # GM values come from Deep Gray Matter regions in the brain
@@ -611,232 +434,136 @@ class volume:
         # Which results in 100/242 = 0.413
         # PD_std = M0_std*0.413
 
+        # ---------- Step 1: piecewise base ----------
         print("Step1 for Texture. Populate phantom with piecewise values")
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-                    pixel = self.volume[i, j, k]
-                    label = self.segmentation_labels[pixel]
-                    l_name = label.name
+        # Build property LUT over label IDs present
+        max_label = int(self.volume.max())
+        base = np.zeros(max_label + 1, dtype=np.float32)
 
-                    # Determine the property value based on the input prop
-                    if prop == "sus":
-                        property_value = label.susceptibility
-                    else:
-                        property_value = self.relax_values[l_name][{
-                            "t2s": 3, "t2": 2, "t1": 1, "pd": 4, "M0": 1
-                        }[prop]]
+        # index mapping for relax_values
+        idx_map = {"sus":0, "t1": 1, "t2": 2, "t2s": 3, "pd": 4}
+        idx_static_map = {"perm3T":0, "cond3T":1, "perm7T":2, "cond7T":3}
 
-                    # Assign the piecewise value directly
-                    self.gaussian_phantom[i, j, k] = property_value
-
-        # Step 2: Apply gaussian distribution only to sc_wm and gm
-
-        print("Step2 for Texture. Calculate gaussian distribution for sc_wm and sc_gm")
-        for l, count in self.unique_counts.items():
-            #label_id = l
-            label_name = self.look_up[l][0]
-            label_sus = self.look_up[l][1]
-            # Determine the property value based on the input prop
-
-            if label_name in ["sc_wm", "sc_gm"]:
-                if prop == "sus":
-                    property_value = label_sus
-                else:
-                    property_value = self.relax_values[label_name][{
-                        "t2s": 3, "t2": 2, "t1": 1, "pd": 4, "M0": 1
-                    }[prop]]
-                std_dev = std_values.get(prop, {}).get(label_name, 0)
-                print(f"Applying Gaussian noise to {label_name} with STD: {std_dev}")
-
-                print(f"Label: {label_name} | Property: {prop} | Mean Value: {property_value} | STD: {std_dev}")
-
-                self.label_gaussians[l] = self.calc_gauss(
-                num_pixels=count,
-                value = property_value,
-                mr_prop=prop,
-                std_dev=std_dev
-                )
-        # Step 3 for Texture. Replacing with gaussian values only in SC WM and SC GM
-        print("Creating gaussian phantom -> longer for big files")
-
-        # Optimized Gaussian Phantom Creation Loop
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-                    pixel = self.volume[i, j, k]
-                    lab_id = self.segmentation_labels[pixel].label_id
-                    # Only apply Gaussian if it is sc_wm or sc_gm
-                    if lab_id in self.label_gaussians:
-                        gaussian_values = self.label_gaussians[lab_id]
-                        value = np.random.choice(gaussian_values)
-                        self.gaussian_phantom[i, j, k] = value
-
-    def create_gauss_dist(self,prop):
-        '''
-        This is an old function S.R. implemented to add gaussian distribution to all labels
-        It could be deleted, but I'm leaving here in case eventually we want to use it again
-        Args:
-            prop:
-
-        Returns:
-
-        '''
-        # For input restrictions of type, see Segmentation Label
-
-        for l, count in self.unique_counts.items():
-            # get the MR property desired
-            # l is the name (as a str) of the label
-            l_name = self.look_up[l][0]
-
-            if l_name not in ["sc_wm", "sc_gm"]:
-                continue  # Skip labels other than sc_wm and sc_gm
+        for lab_id in self.uniq_labels:
+            lab_id = int(lab_id)
+            lbl = self.segmentation_labels.get(lab_id, None)
+            if lbl is None:
+                continue
+            name = lbl.name
 
             if prop == "sus":
-                property_value = self.look_up[l][1]
-                #l_name = self.look_up[l][0]
-                #property = self.look_up[l][1]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 0.0145 # [ppm] => Similar to corpus callosum
-                sc_gm_std = 0.031 # [ppm]
+                val = lbl.susceptibility
+                if val is None:
+                    val = -9.05  # keep your fallback
+            else:
+                # assumes relax_values available and name exists there
+                if prop in ("perm3T", "cond3T", "perm7T", "cond7T"):
+                    # Eventually when mapped completely, replace with
+                    # self.static_vals
+                    val = self.static_vals_short[name][idx_static_map[prop]]
+                else:
+                    val = self.relax_values[name][idx_map[prop]]
 
-                if l_name == "sc_wm":
-                    print(f"STD of Chi of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of Chi of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+            base[lab_id] = float(val)
 
-            if prop == "t2s":
-                l_name = self.look_up[l][0]
-                property = self.relax_values[l_name][3]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 5.4 # [ms]
-                sc_gm_std = 5.6 # [ms]
+        self.gaussian_phantom = base[self.volume].astype(np.float32)
 
-                if l_name == "sc_wm":
-                    print(f"STD of T2* of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of T2* of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+        # ---------- Step 2&3: gaussian on sc_wm + sc_gm ----------
+        print("Step2 for Texture. Calculate gaussian distribution for sc_wm and sc_gm")
+        # Make masks by canonical IDs (fast)
+        # Here: derive IDs from label objects (robust).
+        sc_ids = {}
+        for lab_id in self.uniq_labels:
+            lab_id = int(lab_id)
+            lbl = self.segmentation_labels.get(lab_id, None)
+            if lbl and lbl.name in ("sc_wm", "sc_gm"):
+                sc_ids[lbl.name] = lab_id
 
-            if prop == "t2":
-                l_name = self.look_up[l][0]
-                property = self.relax_values[l_name][2]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 5.4  # [ms]
-                sc_gm_std = 5.6  # [ms]
+        rng = np.random.default_rng()  # optionally pass a seed for reproducibility
 
-                if l_name == "sc_wm":
-                    print(f"STD of T2 (same as T2*) of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of T2 (same as T2*) of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+        for name in ("sc_wm", "sc_gm"):
+            if name not in sc_ids:
+                continue
+            lab_id = sc_ids[name]
+            mask = (self.volume == lab_id)
+            n = int(mask.sum())
+            if n == 0:
+                continue
 
-            if prop == "t1":
-                l_name = self.look_up[l][0]
-                property = self.relax_values[l_name][1]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 42  # [ms]
-                sc_gm_std = 44  # [ms]
-                if l_name == "sc_wm":
-                    print(f"STD of T1 of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of T1 of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+            mean_val = float(base[lab_id])
+            std = float(std_values.get(prop, {}).get(name, 0.0))
 
-            if prop == "pd":
-                l_name = self.look_up[l][0]
-                property = self.relax_values[l_name][4]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 22.31  # [ms]
-                sc_gm_std = 16.83  # [ms]
-                if l_name == "sc_wm":
-                    print(f"STD of PD of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of PD of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+            print(f"Applying Gaussian noise to {name} | prop={prop} | mean={mean_val} | std={std} | n={n}")
 
-            if prop == "M0":
-                l_name = self.look_up[l][0]
-                property = self.relax_values[l_name][1]
-                #SD = self.std_devs[l_name]
-                sc_wm_std = 22.31  # [ms] => Similar to corpus callosum
-                sc_gm_std = 16.83  # [ms] => Avg taken from regions 1 through 7 of QSM RC2 paper (Deep gray matter)
+            if std > 0:
+                self.gaussian_phantom[mask] = rng.normal(loc=mean_val, scale=std, size=n).astype(np.float32)
+            else:
+                self.gaussian_phantom[mask] = mean_val
 
-                if l_name == "sc_wm":
-                    print(f"STD of T1 of {l_name}: {sc_wm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_wm_std)
-                if l_name == "sc_gm":
-                    print(f"STD of T1 of {l_name}: {sc_gm_std}")
-                    self.label_gaussians[l] = self.calc_gauss(num_pixels=count, value=property, mr_prop=prop,
-                                                              std_dev=sc_gm_std)
+        return self.gaussian_phantom
 
-
-
-            # This way for every label we have a gaussian distribution
-
-        print("Creating gaussian phantom -> longer for big files")
-        for i in range(self.dimensions[0]):
-            for j in range(self.dimensions[1]):
-                for k in range(self.dimensions[2]):
-
-                    pixel = self.volume[i,j,k]
-                    # Now we need the ID of the label from pixel so
-                    lab_id = self.segmentation_labels[pixel].label_id
-                    # Instead of getting the name of the label we get the label id
-                    # Because label gaussian is created per label
-                    # Now randomly select a value from the gaussian distribution
-                    gaussian_values = self.label_gaussians[lab_id]
-                    value = np.random.choice(gaussian_values)
-                    self.gaussian_phantom[i,j,k] = value
-
-        print("Finished creating gaussian distributed, based on: ", prop)
-        # Lastly add the gaussian phantom to a Nifti
-        # And save it to output folder
-    def calc_gauss(self, value, num_pixels, mr_prop, std_dev):
-        val = np.random.normal(value, std_dev, num_pixels)
-        # In areas close to 0, the gaussian distribution must always return positive values
-        # It is not possible to have negative T1, T2, T2s or PD. But susceptibility can be negative
-        if mr_prop == "sus":
-            return val
-        else:
-            abs_val = np.abs(val)
-            return abs_val
-
-    def save_gauss_dist(self, type, out_fn = "default"):
+    def save_gauss_dist(self, mrprop, out_fn = "default"):
         #Saving the gaussian distribution with type defined
         # This must be run ONLY after creating the create_property.
         # If not it will automatically save the empty array
         self.gauss_flag = 1
-        if type == 'sus':
-            self.save_sus_dist_nii(out_fn)
+        if mrprop == 'sus':
+            self.save_sus_dist(out_fn)
 
-        if type == 't2s':
+        elif mrprop == 't2s':
             self.save_t2star_dist(out_fn)
 
-        if type == 'pd':
+        elif mrprop == 'pd':
             self.save_pd_dist(out_fn)
 
-        if type == 't1':
+        elif mrprop == 't1':
             self.save_t1_dist(out_fn)
 
-        if type == 't2':
+        elif mrprop == 't2':
             self.save_t2_dist(out_fn)
+
+        elif mrprop in ("perm3T", "cond3T", "perm7T", "cond7T"):
+            self.save_static_vol(out_fn)
+
+    def check_labels(self):
+        for i in self.uniq_labels:
+            if self.segmentation_labels[i].name == None:
+                print("Label: ",self.segmentation_labels[i]["name"]," doesn't have name assigned")
+    def set_label_susceptibility(self, label_id, susceptibility):
+        ids = self.look_up.keys()
+        if label_id in ids:
+            self.segmentation_labels[label_id].set_susceptibility(susceptibility)
+        else:
+            print(f"Label ID {label_id} not found.")
+            exit()
+    def set_T1(self, label_id, t1):
+        ids = self.look_up.keys()
+        if label_id in ids:
+            self.segmentation_labels[label_id].set_t2star_val(t1)
+        else:
+            print(f"Label ID {label_id} not found.")
+            exit()
+    def set_label_pd(self,label_id,pd):
+        ids = self.look_up.keys()
+        if label_id in ids:
+            self.segmentation_labels[label_id].set_pd_val(pd)
+        else: print(f"Label ID {label_id} not found.")
+    def set_T2star(self, label_id, t2star):
+        ids = self.look_up.keys()
+        if label_id in ids:
+            self.segmentation_labels[label_id].set_t2star_val(t2star)
+        else:
+            print(f"Label ID {label_id} not found.")
+    def manual_label(self,id,name,sus):
+        if id in self.uniq_labels:
+            label = self.segmentation_labels[id]
+            label.name = name
+            label.sus = sus
+    def show_labels(self):
+        for i in self.segmentation_labels:
+            label = self.segmentation_labels[i]
+            print(label) # Calling __str__ from label
+
+
     def __repr__(self):
         return f"SegmentationLabelManager == Volume"

--- a/tissue2mrprop/functions/volume.py
+++ b/tissue2mrprop/functions/volume.py
@@ -4,7 +4,7 @@ from tissue2mrprop.functions.label import SegmentationLabel
 import nibabel as nib
 from tissue2mrprop.functions.utils.get_dic_values import to_csv_sus
 import os
-from tissue2mrprop.functions.utils.select_tool import return_dict_labels
+from tissue2mrprop.functions.utils.select_tool import return_dict_labels, new_return_dict_labels
 #from skimage.measure import label, regionprops
 
 # Parent class for the creation of a non-finite biomechanical model of the body
@@ -21,6 +21,7 @@ class volume:
         self.dimensions = np.array(self.volume.shape) # It is initially a tuple, but it needs to be an array
         self.uniq_labels = np.unique(self.volume)
         self.segmentation_labels = {}
+        self.grouped_labels = None
         self.sus_dist = None
         self.t2star_vol = None
         self.pd_dist = None
@@ -73,28 +74,29 @@ class volume:
             # If the version is dynamic
             # The new value will replace None
             # We can check just in case
-            self.look_up = return_dict_labels(tool,version, new_chi = self.new_chi)
+            self.look_up = new_return_dict_labels(tool,version, new_chi = self.new_chi)
         else:
-            self.look_up = return_dict_labels(tool,version)
+            self.look_up = new_return_dict_labels(tool,version)
 
         # Function to get the relaxation values from label
         for i in self.look_up.keys():
             self.segmentation_labels[i] = SegmentationLabel(i)
 
         for key, value in self.look_up.items():
-            # Key is the number of ID and value is (name, sus)
+            # Key is the number of ID and value is (name, new_id)
             name = value[0]
-            sus = value[1]
+            new_id = value[1]
+            self.set_label_name(key, name, type)
+
 
             if ref != 0:
                 new_sus = sus - ref
                 self.set_label_susceptibility(key, new_sus)
 
-            self.set_label_name(key, name, type)
-            self.set_label_susceptibility(key, sus)
+
 
             if type == "sus":
-                print(name, " Chi:", sus)
+                print(name, " Chi:", self.segmentation_labels[key].PD_val)
             if type == "pd":
                 print(name, " PD:", self.segmentation_labels[key].PD_val)
             if type == "t2s":
@@ -252,6 +254,17 @@ class volume:
             else:
                 print("Input has correct pixel integrity!")
                 return 0
+
+    def create_new_grouped_labels(self):
+        self.grouped_labels = np.zeros(self.dimensions)
+
+        for i in range(self.dimensions[0]):
+            for j in range(self.dimensions[1]):
+                for k in range(self.dimensions[2]):
+
+                    pixel = self.volume[i,j,k]
+                    label = self.segmentation_labels[pixel]
+                    new_label_id = self.segmentation_labels
 
     def create_sus_dist(self):
         # Code for create a susceptibility distribution volume


### PR DESCRIPTION
# Segmentation Refactor & New `seg_converter` Tool

## Overview

This PR introduces a canonical label system and fully refactors the segmentation-to-MR-property conversion pipeline using a LUT-based approach for volume generation.

The goal is to unify segmentation handling across tools and significantly improve performance, clarity, and maintainability.

---

## Changes

### Canonical Label System

- Introduced a canonical label mapping independent of segmentation tool inside [[here][tissue2mrprop/conventions.py]](https://github.com/shimming-toolbox/tissue-to-MRproperty/blob/ca365616cb703ef64a87146b98cc99359193f66b/tissue2mrprop/conventions.py#L3C1-L3C13)

- All external segmentation tools (e.g. TotalSegmentator) are remapped into a unified internal label convention which we can expand, addressing #24 discussion.

- Eliminates duplication and ambiguity between tools. Solves #15 

---

### New `seg_converter` CLI Tool

- Added a dedicated `seg_converter` command.
- Converts arbitrary segmentation tools into canonical format.
- Performs automatic pixel integrity validation and saves invalid-label maps (`_invalid_labels.nii.gz`) when inconsistencies are detected when trying to remap from a tool to our canonical labelling system.

---


### Removal of Triple Nested Loops

- Eliminated voxel-wise Python loops for MR property generation.
- Replaced with Lookup Table (LUT) vectorized mapping for faster computation

---
### Updated README

Updated the description of the repo, how to use both tools. Fixes #30 